### PR TITLE
fix: Add Homebrew bin directories to Zsh path

### DIFF
--- a/chezmoi/private_dot_config/zsh/dot_zshenv
+++ b/chezmoi/private_dot_config/zsh/dot_zshenv
@@ -9,7 +9,7 @@ skip_global_compinit=1
 home_zshenv=${HOME}/.zshenv
 [[ -f "${home_zshenv}" ]] && source "${home_zshenv}" || true
 
-typeset -U path=(${HOME}{/.local,}/{,s}bin(N) ${(Oaz)^NIX_PROFILES}/bin ${^path}(N))
+typeset -U path=(${HOME}{/.local,}/{,s}bin(N) ${(Oaz)^NIX_PROFILES}/bin /opt/homebrew/{,s}bin(N) ${^path}(N))
 
 export XDG_CACHE_HOME=${HOME}/.cache
 export XDG_CONFIG_HOME=${HOME}/.config


### PR DESCRIPTION
Updated the Zsh environment configuration to include /opt/homebrew/bin and /opt/homebrew/sbin in the PATH. This ensures Homebrew-installed binaries are available in the shell.