### PR TITLE
feat: add AI CLI tools and refactor chezmoi config variables

### DIFF
--- a/chezmoi/.chezmoi.toml.tmpl
+++ b/chezmoi/.chezmoi.toml.tmpl
@@ -19,9 +19,10 @@
 sourceDir = "{{ .chezmoi.sourceDir }}"
 
 [data]
-name = "yxtay"
+username = "yuxuantay"
+git_user = "yxtay"
 git_email = "5795122+yxtay@users.noreply.github.com"
-work_git_email = "tay.yuxuan@gt.tech.gov.sg"
+git_email_work = "tay.yuxuan@gt.tech.gov.sg"
 arch = "{{ $arch }}"
 os = "{{ $os }}"
 is_ephemeral = {{ $ephemeral }}

--- a/chezmoi/private_dot_config/git/config.tmpl
+++ b/chezmoi/private_dot_config/git/config.tmpl
@@ -91,8 +91,9 @@
 
 [user]
   email = "{{ .git_email }}"
-  name = "{{ .name }}"
+  name = "{{ .git_user }}"
 
+{{- if not .is_ephemeral }}
 [includeIf "gitdir:~/work/"]
   path = "~/.config/git/work_config"
 
@@ -101,6 +102,7 @@
 
 [includeIf "hasconfig:remote.*.url:https://sgts.gitlab-dedicated.com/**"]
   path = "~/.config/git/work_config"
+{{- end }}
 
 [include]
   path = "~/.config/git/alias"

--- a/chezmoi/private_dot_config/git/work_config.tmpl
+++ b/chezmoi/private_dot_config/git/work_config.tmpl
@@ -2,7 +2,7 @@
   pushInsteadOf = "https://sgts.gitlab-dedicated.com/"
 
 [user]
-  email = "{{ .work_git_email }}"
+  email = "{{ .git_email_work }}"
   signingkey = ~/.ssh/id_ed25519_work.pub
 
 [gpg]

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -85,6 +85,7 @@ inputs@{
       "adguard"
       "brave-browser"
       "firefox"
+      "tailscale-app"
 
       # communication
       "microsoft-auto-update" # for microsoft-teams

--- a/modules/home/apps.nix
+++ b/modules/home/apps.nix
@@ -52,6 +52,11 @@
     azure-cli
     databricks-cli
     google-cloud-sdk
+
+    # ai
+    claude-code
+    gemini-cli
+    qwen-code
   ];
 
   programs.java = {


### PR DESCRIPTION
## Summary
- Add AI CLI tools (`claude-code`, `gemini-cli`, `qwen-code`) to nix home apps and `tailscale-app` to Homebrew casks
- Refactor chezmoi config variables: rename `name` → `git_user`/`username` and `work_git_email` → `git_email_work` for consistency
- Guard work git config includes behind `is_ephemeral` check to avoid applying work settings on ephemeral machines

## Test Plan
- [x] Run `chezmoi apply` and verify git config renders correctly with new variable names
- [x] Verify AI CLI tools install via `nix` on a new machine