### PR TITLE
fix(pre-commit): exclude .zsh files from shfmt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,7 +87,7 @@ repos:
     hooks:
       - id: shfmt
         args: [--write]
-        exclude: \.zsh$
+        exclude: (\.|_)zsh(env|rc)?$
 
   - repo: https://github.com/ComPWA/taplo-pre-commit
     rev: v0.9.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,6 +87,7 @@ repos:
     hooks:
       - id: shfmt
         args: [--write]
+        exclude: \.zsh$
 
   - repo: https://github.com/ComPWA/taplo-pre-commit
     rev: v0.9.3

--- a/chezmoi/dot_editorconfig
+++ b/chezmoi/dot_editorconfig
@@ -17,9 +17,7 @@ trim_trailing_whitespace=false
 
 [{*.{py,rs},Dockerfile}]
 indent_size=4
-tab_width=4
 
-[{*.{go,lua,tsv},go.{mod,sum},Makefile}]
-indent_size=4
+[{*.{go,lua},go.{mod,sum},Makefile}]
 indent_style=tab
 tab_width=4


### PR DESCRIPTION
## Summary
- Exclude `.zsh` files from shfmt pre-commit hook
- shfmt's zsh support is incomplete and fails on valid zsh syntax (parameter expansion flags like `${(Oaz)^...}` and short-form `for` loops)
- Matches the existing approach of excluding zsh files from shellcheck

## Test plan
- [x] `pre-commit run shfmt --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)