### PR TITLE
feat: add CLAUDE.md and update configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.log
 megalinter-reports/
+settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Personal macOS dotfiles managed with two complementary tools:
+
+- **Nix flakes** (`nix-darwin` + `home-manager`) for declarative system/user package management
+- **chezmoi** for templated shell/tool config files (zsh, git, helix, wezterm, bat)
+
+Host: `Mac` | User: `yuxuantay` (defined in `flake.nix`)
+
+## Commands
+
+```bash
+# Enter dev shell (provides extra tools for working in this repo)
+nix develop
+
+# Format all files (deadnix, prettier, shellcheck, shfmt, statix, taplo, yamlfmt)
+nix fmt
+
+# Check flake validity (runs in CI)
+nix flake check
+
+# Run pre-commit hooks locally
+uv run pre-commit run --all-files
+
+# Apply system config (nix-darwin) — requires sudo
+sudo nix run nix-darwin -- switch --flake .#Mac
+
+# Apply user config (home-manager standalone)
+nix run home-manager -- switch --flake .#yuxuantay
+
+# Apply chezmoi dotfiles
+chezmoi apply
+
+# Bootstrap from scratch
+./install.sh
+```
+
+## Architecture
+
+### Nix modules (`modules/`)
+
+- `flake-parts/` — Flake composition: wires together darwin, home-manager, treefmt, git-hooks, and devshell. Entry point for `flake.nix`.
+- `darwin/` — macOS system-level config: Homebrew casks/formulae, keyboard, networking, system defaults, zsh system shell.
+- `home/` — User-level packages and programs via home-manager: CLI tools (`apps.nix`), git, zsh, helix, tmux, wezterm, fonts, GNU utils.
+
+### Chezmoi (`chezmoi/`)
+
+`.chezmoiroot` sets `chezmoi/` as the source directory. Files use chezmoi naming conventions (`private_dot_config/`, `dot_`, `symlink_`, `.tmpl`). Templates get data from `.chezmoi.toml.tmpl`.
+
+### CI (`.github/workflows/`)
+
+- `ci.yml` — Runs `nix flake check` + `nix fmt` on macOS, tests chezmoi install
+- `pr.yml` — MegaLinter on PRs
+- `update.yml` — Automated flake/dependency updates
+
+### Dependency management
+
+- **Renovate** auto-updates pre-commit hooks and GitHub Actions (configured in `renovate.json`)
+- **Dependabot** as secondary updater
+- Nix flake inputs pinned via `flake.lock`
+
+## Conventions
+
+- Nix files are formatted with `nixfmt-rfc-style` (via treefmt/git-hooks)
+- Shell scripts exclude `.zsh` files from shellcheck/shfmt (zsh-specific syntax)
+- Pre-commit hooks enforce formatting on commit; CI verifies no uncommitted formatting changes
+- Commits follow conventional commits style (see git log)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,14 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code (claude.ai/code) when working
+with code in this repository.
 
 ## Overview
 
 Personal macOS dotfiles managed with two complementary tools:
 
-- **Nix flakes** (`nix-darwin` + `home-manager`) for declarative system/user package management
+- **Nix flakes** (`nix-darwin` + `home-manager`) for declarative
+  system/user package management
 - **chezmoi** for templated shell/tool config files (zsh, git, helix, wezterm, bat)
 
 Host: `Mac` | User: `yuxuantay` (defined in `flake.nix`)
@@ -43,13 +45,20 @@ chezmoi apply
 
 ### Nix modules (`modules/`)
 
-- `flake-parts/` — Flake composition: wires together darwin, home-manager, treefmt, git-hooks, and devshell. Entry point for `flake.nix`.
-- `darwin/` — macOS system-level config: Homebrew casks/formulae, keyboard, networking, system defaults, zsh system shell.
-- `home/` — User-level packages and programs via home-manager: CLI tools (`apps.nix`), git, zsh, helix, tmux, wezterm, fonts, GNU utils.
+- `flake-parts/` — Flake composition: wires together darwin,
+  home-manager, treefmt, git-hooks, and devshell.
+  Entry point for `flake.nix`.
+- `darwin/` — macOS system-level config: Homebrew casks/formulae,
+  keyboard, networking, system defaults, zsh system shell.
+- `home/` — User-level packages and programs via home-manager:
+  CLI tools (`apps.nix`), git, zsh, helix, tmux, wezterm, fonts.
 
 ### Chezmoi (`chezmoi/`)
 
-`.chezmoiroot` sets `chezmoi/` as the source directory. Files use chezmoi naming conventions (`private_dot_config/`, `dot_`, `symlink_`, `.tmpl`). Templates get data from `.chezmoi.toml.tmpl`.
+`.chezmoiroot` sets `chezmoi/` as the source directory. Files use
+chezmoi naming conventions (`private_dot_config/`, `dot_`,
+`symlink_`, `.tmpl`). Templates get data from
+`.chezmoi.toml.tmpl`.
 
 ### CI (`.github/workflows/`)
 
@@ -67,5 +76,6 @@ chezmoi apply
 
 - Nix files are formatted with `nixfmt-rfc-style` (via treefmt/git-hooks)
 - Shell scripts exclude `.zsh` files from shellcheck/shfmt (zsh-specific syntax)
-- Pre-commit hooks enforce formatting on commit; CI verifies no uncommitted formatting changes
+- Pre-commit hooks enforce formatting on commit;
+  CI verifies no uncommitted formatting changes
 - Commits follow conventional commits style (see git log)

--- a/chezmoi/private_dot_config/zsh/dot_zshenv
+++ b/chezmoi/private_dot_config/zsh/dot_zshenv
@@ -19,7 +19,7 @@ export ZDOTDIR=${XDG_CONFIG_HOME}/zsh
 
 # custom SSL certificate
 export NODE_USE_SYSTEM_CA=1
-export UV_NATIVE_TLS=true
+export UV_SYSTEM_CERTS=true
 cert_file=${HOME}/.config/cloudflare/cert.pem
 if [[ -f "${cert_file}" ]]; then
   export AWS_CA_BUNDLE=${cert_file}

--- a/modules/home/apps.nix
+++ b/modules/home/apps.nix
@@ -44,8 +44,6 @@
     # kind
     kubectl
     # kubernetes-helm
-    # podman
-    # podman-compose
 
     # work
     awscli2
@@ -56,7 +54,6 @@
     # ai
     claude-code
     gemini-cli
-    qwen-code
   ];
 
   programs.java = {


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` with repo architecture, common commands, and conventions for Claude Code
- Update `UV_NATIVE_TLS` → `UV_SYSTEM_CERTS` in zsh env (renamed upstream)
- Add `settings.local.json` to `.gitignore`
- Remove unused packages (qwen-code, podman) from `apps.nix`

## Test plan
- [x] `nix flake check` passes
- [x] `nix fmt` reports no changes
- [x] `chezmoi apply` applies cleanly

🤖 Generated with [Claude Code](https://claude.ai/code)