### PR TITLE
chore: Remove GitHub pushInsteadOf url alias

### DIFF
--- a/chezmoi/private_dot_config/git/config.tmpl
+++ b/chezmoi/private_dot_config/git/config.tmpl
@@ -86,9 +86,6 @@
 [transfer]
   fsckobjects = true
 
-[url "git@github.com:"]
-  pushInsteadOf = "https://github.com/"
-
 [user]
   email = "{{ .git_email }}"
   name = "{{ .git_user }}"


### PR DESCRIPTION
Delete the [url "git@github.com:"] pushInsteadOf entry from chezmoi/private_dot_config/git/config.tmpl. This stops automatic rewriting of https://github.com/ push URLs to the git@github.com: SSH form, avoiding surprising transport changes while keeping the user name/email settings intact.