### PR TITLE
docs(agents): improve AGENTS.md conventions

### DIFF
--- a/chezmoi/private_dot_agents/AGENTS.md
+++ b/chezmoi/private_dot_agents/AGENTS.md
@@ -86,7 +86,7 @@ Resume terse after clear part done.
 - Keep changes minimal. No unrelated cleanup.
 - No premature abstractions. Three similar lines
   beat a premature helper.
-- When bug found, capture root cause as rule
+- When bug found, capture root cause as a code invariant or test case
   so same class of mistake never recurs.
 
 ## Security
@@ -116,7 +116,7 @@ Resume terse after clear part done.
   - No trailing period on subject line.
   - Body only when "why" isn't obvious from subject.
   - Never write "This commit does X",
-    "I", "we", "now" in body — diff says what.
+    "I", "we" in body — diff says what.
 - Push the feature branch regularly
   so work isn't lost.
 - When the task is complete,

--- a/chezmoi/private_dot_agents/AGENTS.md
+++ b/chezmoi/private_dot_agents/AGENTS.md
@@ -27,6 +27,9 @@ Answer fast, use minimal words, no fluff.
   No "Great question", "Good catch", or apologies.
 - Drop articles:
   "Me fix code" not "I will fix the code."
+- Pattern: `[thing] [action] [reason]. [next step].`
+- Off-switch: "stop caveman" or "normal mode"
+  reverts to normal output.
 
 ### When to Expand
 
@@ -35,6 +38,18 @@ Answer fast, use minimal words, no fluff.
 - Architecture decision unclear —
   ask one concise question.
 - Otherwise: stay terse.
+
+### Auto-Clarity
+
+Drop terse mode temporarily for:
+
+- Security warnings.
+- Irreversible action confirmations.
+- Multi-step sequences where fragment order
+  or omitted conjunctions risk misread.
+- User asks to clarify or repeats question.
+
+Resume terse after clear part done.
 
 ## Task Workflow
 
@@ -71,6 +86,8 @@ Answer fast, use minimal words, no fluff.
 - Keep changes minimal. No unrelated cleanup.
 - No premature abstractions. Three similar lines
   beat a premature helper.
+- When bug found, capture root cause as rule
+  so same class of mistake never recurs.
 
 ## Security
 
@@ -94,9 +111,12 @@ Answer fast, use minimal words, no fluff.
     `test`, `chore`, `ci`, `build`, `perf`, `style`
   - Scope is optional but encouraged
     when it adds clarity.
-  - Subject line ≤ 50 characters, imperative mood.
-  - Add a body when the "why" isn't obvious
-    from the subject.
+  - Subject line ≤ 50 characters, imperative mood
+    ("add", "fix", "remove" — not "added", "adds").
+  - No trailing period on subject line.
+  - Body only when "why" isn't obvious from subject.
+  - Never write "This commit does X",
+    "I", "we", "now" in body — diff says what.
 - Push the feature branch regularly
   so work isn't lost.
 - When the task is complete,


### PR DESCRIPTION
## Summary
- Add auto-clarity rules: drop terse mode for security warnings, irreversible actions, ambiguous multi-step sequences
- Add response pattern template and off-switch documentation to Communication Rules
- Add bug-to-invariant feedback rule under Code Quality
- Tighten commit message conventions: imperative mood examples, no trailing period, body-only-when-needed, banned filler phrases

Inspired by review of [caveman](https://github.com/JuliusBrussee/caveman), [cavemem](https://github.com/JuliusBrussee/cavemem), and [cavekit](https://github.com/JuliusBrussee/cavekit) repos.

## Test plan
- [ ] Verify `chezmoi apply` works with updated AGENTS.md
- [ ] Confirm markdown linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)