### PR TITLE
chore: remove redundant pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,16 +5,6 @@ default_stages:
   - pre-commit
 
 repos:
-  - repo: https://github.com/pre-commit/pre-commit
-    rev: v4.6.0
-    hooks:
-      - id: validate_manifest
-
-  - repo: meta
-    hooks:
-      #   - id: check-hooks-apply
-      - id: check-useless-excludes
-
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
@@ -38,11 +28,6 @@ repos:
       - id: check-vcs-permalinks
       - id: no-commit-to-branch
       - id: forbid-new-submodules
-
-        # security
-      - id: detect-aws-credentials
-        args: [--allow-missing-credentials]
-      - id: detect-private-key
 
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.30.1


### PR DESCRIPTION
## Summary
- Remove `validate_manifest` and `check-useless-excludes` meta hooks
- Remove `detect-aws-credentials` and `detect-private-key` hooks — covered by gitleaks
- Simplifies pre-commit config by dropping checks already handled by megalinter and gitleaks

## Test plan
- [ ] `uv run pre-commit run --all-files` passes
- [ ] CI passes (`nix flake check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>