### PR TITLE
refactor: replace is_codespaces with is_ephemeral

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,0 @@
-{
-  "image": "mcr.microsoft.com/devcontainers/universal",
-  "runArgs": ["--platform=linux/amd64"]
-}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
+      - run: chezmoi data
+        shell: zsh {0}
+
       - run: |
           echo ${ZSH_NAME} ${ZSH_VERSION}
           echo path: ${path}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,13 +31,20 @@ chezmoi naming conventions (`private_dot_config/`, `dot_`,
 
 Key scripts:
 
-- `run_before_brew_bundle_install.sh.tmpl` — installs all Homebrew packages/casks
+- `run_once_before_00_install_homebrew.sh.tmpl` — installs Homebrew (runs once)
+- `run_once_before_rosetta.sh.tmpl` — installs Rosetta 2 (runs once)
+- `run_before_01_brew_bundle_install.sh.tmpl` — installs all Homebrew packages/casks
 - `run_onchange_macos_defaults.sh.tmpl` — applies macOS system settings
+- `run_onchange_setup_claude.sh` — configures Claude Code
+- `run_onchange_setup_gemini.sh.tmpl` — configures Gemini
 
 ### CI (`.github/workflows/`)
 
 - `ci.yml` — Tests chezmoi install
 - `pr.yml` — MegaLinter on PRs
+- `ossf.yml` — OpenSSF Scorecard security scan
+- `scans.yml` — Additional security scans
+- `automerge.yml` — Auto-merges passing Renovate/Dependabot PRs
 
 ### Dependency management
 

--- a/chezmoi/.chezmoi.toml.tmpl
+++ b/chezmoi/.chezmoi.toml.tmpl
@@ -1,6 +1,6 @@
 {{- $is_ci := eq (env "CI") "true" }}
-{{- $is_codespaces := or $is_ci (eq "true" (env "CODESPACES") (env "REMOTE_CONTAINERS")) }}
-{{- $is_ephemeral := or $is_codespaces (eq .chezmoi.username "debian" "root" "ubuntu" "user") }}
+{{- $is_ephemeral := or $is_ci (eq "true" (env "CODESPACES") (env "REMOTE_CONTAINERS")) }}
+{{- $is_ephemeral := or $is_ephemeral (eq .chezmoi.username "debian" "ubuntu" "user") }}
 {{- $interactive := stdinIsATTY }}
 
 {{- $arch := "x86_64" }}
@@ -25,7 +25,6 @@ git_email_work = "tay.yuxuan@gt.tech.gov.sg"
 arch = "{{ $arch }}"
 os = "{{ $os }}"
 is_ci = {{ $is_ci }}
-is_codespaces = {{ $is_codespaces }}
 is_ephemeral = {{ $is_ephemeral }}
 is_interactive = {{ $interactive }}
 

--- a/chezmoi/.chezmoi.toml.tmpl
+++ b/chezmoi/.chezmoi.toml.tmpl
@@ -1,5 +1,5 @@
 {{- $is_ephemeral := eq "true" (env "CI") (env "CODESPACES") (env "REMOTE_CONTAINERS") }}
-{{- $is_ephemeral := or $is_ephemeral (eq .chezmoi.username "debian" "ubuntu" "user") }}
+{{- $is_ephemeral = or $is_ephemeral (eq .chezmoi.username "debian" "ubuntu" "user") }}
 {{- $interactive := stdinIsATTY }}
 
 {{- $arch := "x86_64" }}

--- a/chezmoi/.chezmoi.toml.tmpl
+++ b/chezmoi/.chezmoi.toml.tmpl
@@ -1,5 +1,4 @@
-{{- $is_ci := eq (env "CI") "true" }}
-{{- $is_ephemeral := or $is_ci (eq "true" (env "CODESPACES") (env "REMOTE_CONTAINERS")) }}
+{{- $is_ephemeral := eq "true" (env "CI") (env "CODESPACES") (env "REMOTE_CONTAINERS") }}
 {{- $is_ephemeral := or $is_ephemeral (eq .chezmoi.username "debian" "ubuntu" "user") }}
 {{- $interactive := stdinIsATTY }}
 
@@ -24,7 +23,6 @@ git_email = "5795122+yxtay@users.noreply.github.com"
 git_email_work = "tay.yuxuan@gt.tech.gov.sg"
 arch = "{{ $arch }}"
 os = "{{ $os }}"
-is_ci = {{ $is_ci }}
 is_ephemeral = {{ $is_ephemeral }}
 is_interactive = {{ $interactive }}
 

--- a/chezmoi/.chezmoiexternal.toml.tmpl
+++ b/chezmoi/.chezmoiexternal.toml.tmpl
@@ -14,7 +14,7 @@
 {{- end }}
   refreshPeriod = "168h"
 
-{{- if .is_codespaces }}
+{{- if .is_ephemeral }}
 [".local/bin/bat"]
   type = "archive-file"
   url = "{{ gitHubLatestReleaseAssetURL "sharkdp/bat" (printf "bat-*-%s-%s.tar.gz" .arch .os) }}"

--- a/chezmoi/run_before_01_brew_bundle_install.sh.tmpl
+++ b/chezmoi/run_before_01_brew_bundle_install.sh.tmpl
@@ -1,4 +1,4 @@
-{{ if and (eq .chezmoi.os "darwin") (not .is_ci) -}}
+{{ if and (eq .chezmoi.os "darwin") (not .is_ephemeral) -}}
 #!/usr/bin/env bash
 set -euo pipefail
 

--- a/chezmoi/run_once_before_00_install_homebrew.sh.tmpl
+++ b/chezmoi/run_once_before_00_install_homebrew.sh.tmpl
@@ -1,4 +1,4 @@
-{{ if and (eq .chezmoi.os "darwin") (not .is_ci) -}}
+{{ if and (eq .chezmoi.os "darwin") (not .is_ephemeral) -}}
 #!/usr/bin/env bash
 set -euo pipefail
 

--- a/chezmoi/run_once_before_rosetta.sh.tmpl
+++ b/chezmoi/run_once_before_rosetta.sh.tmpl
@@ -1,4 +1,4 @@
-{{ if and (eq .chezmoi.os "darwin") (not .is_ci) -}}
+{{ if and (eq .chezmoi.os "darwin") (not .is_ephemeral) -}}
 #!/usr/bin/env bash
 softwareupdate --install-rosetta --agree-to-license
 {{ end -}}

--- a/chezmoi/run_onchange_macos_defaults.sh.tmpl
+++ b/chezmoi/run_onchange_macos_defaults.sh.tmpl
@@ -1,4 +1,4 @@
-{{ if and (eq .chezmoi.os "darwin") (not .is_ci) -}}
+{{ if and (eq .chezmoi.os "darwin") (not .is_ephemeral) -}}
 #!/usr/bin/env bash
 set -euo pipefail
 

--- a/chezmoi/run_onchange_setup_gemini.sh.tmpl
+++ b/chezmoi/run_onchange_setup_gemini.sh.tmpl
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-{{ if .is_codespaces -}}
+{{ if .is_ephemeral -}}
 if ! command -v gemini >/dev/null && command -v npm >/dev/null; then
   npm install -g @google/gemini-cli
 fi


### PR DESCRIPTION
## Summary

- Consolidate `is_codespaces`, `is_ci`, and ephemeral detection into single `is_ephemeral` flag
- Replace all `is_ci` / `is_codespaces` references across chezmoi scripts and templates
- Remove unused `.devcontainer/devcontainer.json`
- Update `AGENTS.md` with accurate key scripts and CI workflow list

## Test plan

- [ ] `chezmoi apply` on macOS (non-ephemeral) — no behavior change
- [ ] `chezmoi apply` in CI / Codespaces — ephemeral path still triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)