### PR TITLE
refactor(chezmoi): improve config and expand macOS defaults

### DIFF
--- a/chezmoi/.chezmoi.toml.tmpl
+++ b/chezmoi/.chezmoi.toml.tmpl
@@ -40,6 +40,6 @@ autoCommit = true
 
 [scriptEnv]
 {{- if not $is_interactive }}
-DEBIAN_FRONTEND=noninteractive
-NONINTERACTIVE=true
+DEBIAN_FRONTEND = "noninteractive"
+NONINTERACTIVE = true
 {{- end }}

--- a/chezmoi/.chezmoi.toml.tmpl
+++ b/chezmoi/.chezmoi.toml.tmpl
@@ -25,7 +25,6 @@ is_ephemeral = {{ $is_ephemeral }}
 is_interactive = {{ $is_interactive }}
 
 {{- if not $is_ephemeral }}
-username = "yuxuantay"
 git_email_work = "tay.yuxuan@gt.tech.gov.sg"
 {{- end }}
 

--- a/chezmoi/.chezmoi.toml.tmpl
+++ b/chezmoi/.chezmoi.toml.tmpl
@@ -16,6 +16,11 @@
 {{- $os = "pc-windows-msvc" }}
 {{- end }}
 
+{{- if lookPath "delta" }}
+pager = "delta"
+{{- end }}
+progress = true
+
 [data]
 git_user = "yxtay"
 git_email = "5795122+yxtay@users.noreply.github.com"
@@ -34,8 +39,15 @@ command = "delta"
 pager = "delta"
 {{- end }}
 
+[edit]
+apply = true
+
 [git]
 autoCommit = true
+autoPush = true
+
+[github]
+refreshPeriod = "1h"
 
 [scriptEnv]
 {{- if not $is_interactive }}

--- a/chezmoi/.chezmoi.toml.tmpl
+++ b/chezmoi/.chezmoi.toml.tmpl
@@ -1,6 +1,6 @@
 {{- $is_ephemeral := eq "true" (env "CI") (env "CODESPACES") (env "REMOTE_CONTAINERS") }}
 {{- $is_ephemeral = or $is_ephemeral (eq .chezmoi.username "debian" "ubuntu" "user") }}
-{{- $interactive := stdinIsATTY }}
+{{- $is_interactive := stdinIsATTY }}
 
 {{- $arch := "x86_64" }}
 {{- if eq .chezmoi.arch "arm64" }}
@@ -17,14 +17,17 @@
 {{- end }}
 
 [data]
-username = "yuxuantay"
 git_user = "yxtay"
 git_email = "5795122+yxtay@users.noreply.github.com"
-git_email_work = "tay.yuxuan@gt.tech.gov.sg"
 arch = "{{ $arch }}"
 os = "{{ $os }}"
 is_ephemeral = {{ $is_ephemeral }}
-is_interactive = {{ $interactive }}
+is_interactive = {{ $is_interactive }}
+
+{{- if not $is_ephemeral }}
+username = "yuxuantay"
+git_email_work = "tay.yuxuan@gt.tech.gov.sg"
+{{- end }}
 
 [diff]
 {{- if lookPath "delta" }}
@@ -34,3 +37,9 @@ pager = "delta"
 
 [git]
 autoCommit = true
+
+[scriptEnv]
+{{- if not $is_interactive }}
+DEBIAN_FRONTEND=noninteractive
+NONINTERACTIVE=true
+{{- end }}

--- a/chezmoi/.chezmoi.toml.tmpl
+++ b/chezmoi/.chezmoi.toml.tmpl
@@ -41,5 +41,5 @@ autoCommit = true
 [scriptEnv]
 {{- if not $is_interactive }}
 DEBIAN_FRONTEND = "noninteractive"
-NONINTERACTIVE = true
+NONINTERACTIVE = "true"
 {{- end }}

--- a/chezmoi/.chezmoiignore.tmpl
+++ b/chezmoi/.chezmoiignore.tmpl
@@ -1,3 +1,6 @@
+{{- if .is_ephemeral}}
+.config/git/work_config
+{{- end }}
 {{- if contains ".local/share/chezmoi" .chezmoi.workingTree }}
 .local/share/chezmoi
 {{- end }}

--- a/chezmoi/.chezmoiscripts/run_before_brew_install.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_before_brew_install.sh.tmpl
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # install brew if not exists
 if ! command -v brew >/dev/null; then
-  NONINTERACTIVE=1 bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
   for prefix in /home/linuxbrew/.linuxbrew /opt/homebrew /usr/local; do
     brew=${prefix}/bin/brew

--- a/chezmoi/.chezmoiscripts/run_onchange_macos_defaults.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_macos_defaults.sh.tmpl
@@ -10,12 +10,19 @@ defaults write NSGlobalDomain AppleKeyboardUIMode -int 3                        
 defaults write NSGlobalDomain AppleLanguages -array "en-SG"
 defaults write NSGlobalDomain AppleLocale -string "en_SG"
 defaults write NSGlobalDomain AppleShowAllExtensions -bool true
+defaults write NSGlobalDomain NSAutomaticCapitalizationEnabled -bool false
+defaults write NSGlobalDomain NSAutomaticDashSubstitutionEnabled -bool false
+defaults write NSGlobalDomain NSAutomaticPeriodSubstitutionEnabled -bool false
+defaults write NSGlobalDomain NSAutomaticQuoteSubstitutionEnabled -bool false
+defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool false
 defaults write NSGlobalDomain NSAutomaticWindowAnimationsEnabled -bool false    # disables window open/close animations
-defaults write NSGlobalDomain NSDisableAutomaticTermination -bool true          # prevents apps from silently auto-terminating when unused
 defaults write NSGlobalDomain NSDocumentSaveNewDocumentsToCloud -bool false     # new documents default to local disk, not iCloud
 defaults write NSGlobalDomain "com.apple.sound.beep.feedback" -int 0            # no sound when changing volume with keyboard
 defaults write NSGlobalDomain "com.apple.swipescrolldirection" -bool false      # disable natural scrolling
 defaults write NSGlobalDomain "com.apple.trackpad.trackpadCornerClickBehavior" -int 1  # corner click = secondary click
+
+# Activity Monitor
+defaults write com.apple.ActivityMonitor IconType -int 6         # show CPU usage graph in dock icon
 
 # Advertising
 defaults write com.apple.AdLib allowApplePersonalizedAdvertising -bool false
@@ -45,6 +52,7 @@ defaults write com.apple.dock tilesize -int 56
 # Finder
 defaults write com.apple.finder AppleShowAllFiles -bool true
 defaults write com.apple.finder CreateDesktop -bool false
+defaults write com.apple.finder DisableAllAnimations -bool true
 defaults write com.apple.finder FXDefaultSearchScope -string "SCcf"      # search current folder by default (not whole Mac)
 defaults write com.apple.finder FXEnableExtensionChangeWarning -bool false
 defaults write com.apple.finder FXPreferredViewStyle -string "clmv"      # column view (icnv=icon, Nlsv=list, glyv=gallery)
@@ -55,6 +63,7 @@ defaults write com.apple.finder ShowExternalHardDrivesOnDesktop -bool false
 defaults write com.apple.finder ShowPathbar -bool true
 defaults write com.apple.finder ShowRemovableMediaOnDesktop -bool false
 defaults write com.apple.finder ShowStatusBar -bool true
+defaults write com.apple.finder WarnOnEmptyTrash -bool false
 defaults write com.apple.finder _FXShowPosixPathInTitle -bool true       # shows full Unix path in window title bar
 defaults write com.apple.finder _FXSortFoldersFirst -bool true
 defaults write com.apple.finder _FXSortFoldersFirstOnDesktop -bool true


### PR DESCRIPTION
## Summary

- Move `username`/`git_email_work` under `{{- if not $is_ephemeral }}` guard so ephemeral envs don't get personal data
- Rename `$interactive` → `$is_interactive` for naming consistency
- Move `DEBIAN_FRONTEND`/`NONINTERACTIVE` to `[scriptEnv]` block instead of inline in brew script
- Add smart punctuation/auto-correction disables to macOS defaults
- Add `Finder.DisableAllAnimations`, `Finder.WarnOnEmptyTrash`, `ActivityMonitor.IconType`
- Remove `NSDisableAutomaticTermination` (not useful)

## Test plan

- [ ] `chezmoi apply` on macOS — verify defaults applied
- [ ] `chezmoi apply` in CI/ephemeral — verify personal config not written
- [ ] Brew install works without `NONINTERACTIVE` hardcoded

🤖 Generated with [Claude Code](https://claude.com/claude-code)