### PR TITLE
fix(chezmoi): use bat as pager instead of delta

### DIFF
--- a/chezmoi/.chezmoi.toml.tmpl
+++ b/chezmoi/.chezmoi.toml.tmpl
@@ -19,7 +19,6 @@
 {{- if lookPath "bat" }}
 pager = "bat"
 {{- end }}
-progress = true
 
 [data]
 git_user = "yxtay"

--- a/chezmoi/.chezmoi.toml.tmpl
+++ b/chezmoi/.chezmoi.toml.tmpl
@@ -16,8 +16,8 @@
 {{- $os = "pc-windows-msvc" }}
 {{- end }}
 
-{{- if lookPath "delta" }}
-pager = "delta"
+{{- if lookPath "bat" }}
+pager = "bat"
 {{- end }}
 progress = true
 

--- a/chezmoi/.chezmoi.toml.tmpl
+++ b/chezmoi/.chezmoi.toml.tmpl
@@ -19,6 +19,7 @@
 {{- if lookPath "bat" }}
 pager = "bat"
 {{- end }}
+progress = {{ $is_interactive }}
 
 [data]
 git_user = "yxtay"


### PR DESCRIPTION
## Summary
- Replace `delta` with `bat` as the chezmoi pager

## Test plan
- [ ] Run `chezmoi apply` and verify bat is used as pager

🤖 Generated with [Claude Code](https://claude.com/claude-code)