### PR TITLE
feat(chezmoi): add binary downloads for ephemeral environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,6 @@ jobs:
       - run: chezmoi data --format yaml
         shell: zsh {0}
 
-      - run: brew bundle dump --file -
-        shell: zsh {0}
-
       - run: |
           echo ${ZSH_NAME} ${ZSH_VERSION}
           echo path: ${path}

--- a/chezmoi/.chezmoiexternal.toml.tmpl
+++ b/chezmoi/.chezmoiexternal.toml.tmpl
@@ -89,10 +89,8 @@
   refreshPeriod = "168h"
 
 [".local/bin/yq"]
-  type = "archive-file"
-  url = "{{ gitHubLatestReleaseAssetURL "mikefarah/yq" (printf "yq_%s_%s.tar.gz" .chezmoi.os .chezmoi.arch) }}"
-  path = "{{ printf "yq_%s_%s.tar.gz" .chezmoi.os .chezmoi.arch }}"
-  stripComponents = 1
+  type = "file"
+  url = "{{ gitHubLatestReleaseAssetURL "mikefarah/yq" (printf "yq_%s_%s" .chezmoi.os .chezmoi.arch) }}"
   executable = true
   refreshPeriod = "168h"
 

--- a/chezmoi/.chezmoiexternal.toml.tmpl
+++ b/chezmoi/.chezmoiexternal.toml.tmpl
@@ -91,7 +91,7 @@
 [".local/bin/yq"]
   type = "archive-file"
   url = "{{ gitHubLatestReleaseAssetURL "mikefarah/yq" (printf "yq_%s_%s.tar.gz" .chezmoi.os .chezmoi.arch) }}"
-  path = "yq"
+  path = "{{ printf "yq_%s_%s.tar.gz" .chezmoi.os .chezmoi.arch }}"
   stripComponents = 1
   executable = true
   refreshPeriod = "168h"

--- a/chezmoi/.chezmoiexternal.toml.tmpl
+++ b/chezmoi/.chezmoiexternal.toml.tmpl
@@ -13,3 +13,93 @@
   url = "https://github.com/github/gitignore/raw/main/Global/Linux.gitignore"
 {{- end }}
   refreshPeriod = "168h"
+
+{{- if .is_ephemeral }}
+[".local/bin/bat"]
+  type = "archive-file"
+  url = "{{ gitHubLatestReleaseAssetURL "sharkdp/bat" (printf "bat-*-%s-%s.tar.gz" .arch .os) }}"
+  path = "bat"
+  stripComponents = 1
+  executable = true
+  refreshPeriod = "168h"
+
+[".local/bin/delta"]
+  type = "archive-file"
+  url = "{{ gitHubLatestReleaseAssetURL "dandavison/delta" (printf "delta-*-%s-%s.tar.gz" .arch .os) }}"
+  path = "delta"
+  stripComponents = 1
+  executable = true
+  refreshPeriod = "168h"
+
+{{- if ne .chezmoi.os "darwin" }}
+[".local/bin/eza"]
+  type = "archive-file"
+  url = "{{ gitHubLatestReleaseAssetURL "eza-community/eza" (printf "eza_%s-%s.tar.gz" .arch .os) }}"
+  path = "eza"
+  stripComponents = 1
+  executable = true
+  refreshPeriod = "168h"
+{{- end }}
+
+[".local/bin/fd"]
+  type = "archive-file"
+  url = "{{ gitHubLatestReleaseAssetURL "sharkdp/fd" (printf "fd-*-%s-%s.tar.gz" .arch .os) }}"
+  path = "fd"
+  stripComponents = 1
+  executable = true
+  refreshPeriod = "168h"
+
+[".local/bin/fzf"]
+  type = "archive-file"
+  url = "{{ gitHubLatestReleaseAssetURL "junegunn/fzf" (printf "fzf-*-%s_%s.tar.gz" .chezmoi.os .chezmoi.arch) }}"
+  path = "fzf"
+  executable = true
+  refreshPeriod = "168h"
+
+[".local/bin/rg"]
+  type = "archive-file"
+  url = "{{ gitHubLatestReleaseAssetURL "BurntSushi/ripgrep" (printf "ripgrep-*-%s-*-%s*.tar.gz" .arch .chezmoi.os) }}"
+  path = "rg"
+  stripComponents = 1
+  executable = true
+  refreshPeriod = "168h"
+
+[".local/bin/sd"]
+  type = "archive-file"
+  url = "{{ gitHubLatestReleaseAssetURL "chmln/sd" (printf "sd-*-%s-*-%s*.tar.gz" .arch .chezmoi.os) }}"
+  path = "sd"
+  stripComponents = 1
+  executable = true
+  refreshPeriod = "168h"
+
+[".local/bin/uv"]
+  type = "archive-file"
+  url = "{{ gitHubLatestReleaseAssetURL "astral-sh/uv" (printf "uv-%s-%s.tar.gz" .arch .os) }}"
+  path = "uv"
+  stripComponents = 1
+  executable = true
+  refreshPeriod = "168h"
+
+[".local/bin/uvx"]
+  type = "archive-file"
+  url = "{{ gitHubLatestReleaseAssetURL "astral-sh/uv" (printf "uv-%s-%s.tar.gz" .arch .os) }}"
+  path = "uvx"
+  stripComponents = 1
+  executable = true
+  refreshPeriod = "168h"
+
+[".local/bin/yq"]
+  type = "archive-file"
+  url = "{{ gitHubLatestReleaseAssetURL "mikefarah/yq" (printf "yq_%s_%s.tar.gz" .chezmoi.os .chezmoi.arch) }}"
+  path = "yq"
+  stripComponents = 1
+  executable = true
+  refreshPeriod = "168h"
+
+[".local/bin/zoxide"]
+  type = "archive-file"
+  url = "{{ gitHubLatestReleaseAssetURL "ajeetdsouza/zoxide" (printf "zoxide-*-%s-*-%s*.tar.gz" .arch .chezmoi.os) }}"
+  path = "zoxide"
+  executable = true
+  refreshPeriod = "168h"
+{{- end }}

--- a/chezmoi/.chezmoiscripts/run_before_brew_install.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_before_brew_install.sh.tmpl
@@ -1,3 +1,4 @@
+{{ if not .is_ephemeral -}}
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -15,16 +16,9 @@ if ! command -v brew >/dev/null; then
 fi
 
 brew bundle \
-{{- if not .is_ephemeral }}
 --cleanup --zap \
-{{- end }}
 --file=/dev/stdin <<EOF
 
-brew "fzf"
-brew "yq"
-uv "uv"
-
-{{- if not .is_ephemeral }}
 ###
 # cli utilities
 ###
@@ -40,6 +34,7 @@ brew "tlrc"
 brew "jq"
 brew "ripgrep"
 brew "sd"
+brew "yq"
 
 # files
 brew "bat"
@@ -48,6 +43,7 @@ brew "duf"
 brew "dust"
 brew "eza"
 brew "fd"
+brew "fzf"
 brew "zoxide"
 
 # security
@@ -95,6 +91,7 @@ brew "yarn"
 # python
 uv "pre-commit"
 uv "ruff"
+uv "uv"
 uv "ty"
 
 # work
@@ -189,7 +186,7 @@ cask "intune-company-portal"
 cask "libreoffice"
 
 {{- end }}
-{{- end }}
 EOF
 
 brew bundle dump --global --force
+{{ end -}}


### PR DESCRIPTION
## Summary

- Skip Homebrew install when `is_ephemeral` is true
- Add `gitHubLatestReleaseAssetURL` entries in `.chezmoiexternal.toml.tmpl` for ephemeral envs: bat, delta, eza (non-Darwin), fd, fzf, rg, sd, uv, uvx, yq, zoxide
- Reorganize brew bundle to keep packages in logical groups

## Test plan

- [ ] Apply chezmoi on non-ephemeral macOS — brew install runs as before
- [ ] Apply chezmoi on ephemeral env (`is_ephemeral = true`) — binaries downloaded to `.local/bin/`, brew skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)