### PR TITLE
feat(chezmoi): skip agent skills on ephemeral envs

### DIFF
--- a/chezmoi/.chezmoiscripts/run_after_update_agent_skills.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_after_update_agent_skills.sh.tmpl
@@ -1,3 +1,4 @@
+{{ if not .is_ephemeral -}}
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -6,3 +7,4 @@ if ! command -v npx >/dev/null; then
 fi
 
 npx --yes skills update --global
+{{ end -}}

--- a/chezmoi/.chezmoiscripts/run_onchange_add_agent_skills.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_add_agent_skills.sh.tmpl
@@ -1,3 +1,4 @@
+{{ if not .is_ephemeral -}}
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -20,3 +21,4 @@ skills=(
 for entry in "${skills[@]}"; do
   npx --yes skills add "${entry}" --global "${agent_opt[@]}" --skill "*" --yes
 done
+{{ end -}}


### PR DESCRIPTION
## Summary

- Convert `run_after_update_agent_skills.sh` and `run_onchange_add_agent_skills.sh` to chezmoi templates
- Wrap script body with `{{ if not .is_ephemeral }}` so scripts are no-ops on ephemeral environments

## Test plan

- [ ] Verify `chezmoi apply` on non-ephemeral machine still runs agent skill scripts
- [ ] Verify `chezmoi apply` on ephemeral machine skips agent skill scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)