### PR TITLE
refactor(chezmoi): remove bat, delta, uv, uvx from ephemeral binaries

### DIFF
--- a/chezmoi/.chezmoiexternal.toml.tmpl
+++ b/chezmoi/.chezmoiexternal.toml.tmpl
@@ -15,22 +15,6 @@
   refreshPeriod = "168h"
 
 {{- if .is_ephemeral }}
-[".local/bin/bat"]
-  type = "archive-file"
-  url = "{{ gitHubLatestReleaseAssetURL "sharkdp/bat" (printf "bat-*-%s-%s.tar.gz" .arch .os) }}"
-  path = "bat"
-  stripComponents = 1
-  executable = true
-  refreshPeriod = "168h"
-
-[".local/bin/delta"]
-  type = "archive-file"
-  url = "{{ gitHubLatestReleaseAssetURL "dandavison/delta" (printf "delta-*-%s-%s.tar.gz" .arch .os) }}"
-  path = "delta"
-  stripComponents = 1
-  executable = true
-  refreshPeriod = "168h"
-
 {{- if ne .chezmoi.os "darwin" }}
 [".local/bin/eza"]
   type = "archive-file"
@@ -68,22 +52,6 @@
   type = "archive-file"
   url = "{{ gitHubLatestReleaseAssetURL "chmln/sd" (printf "sd-*-%s-*-%s*.tar.gz" .arch .chezmoi.os) }}"
   path = "sd"
-  stripComponents = 1
-  executable = true
-  refreshPeriod = "168h"
-
-[".local/bin/uv"]
-  type = "archive-file"
-  url = "{{ gitHubLatestReleaseAssetURL "astral-sh/uv" (printf "uv-%s-%s.tar.gz" .arch .os) }}"
-  path = "uv"
-  stripComponents = 1
-  executable = true
-  refreshPeriod = "168h"
-
-[".local/bin/uvx"]
-  type = "archive-file"
-  url = "{{ gitHubLatestReleaseAssetURL "astral-sh/uv" (printf "uv-%s-%s.tar.gz" .arch .os) }}"
-  path = "uvx"
   stripComponents = 1
   executable = true
   refreshPeriod = "168h"


### PR DESCRIPTION
## Summary

- Remove `bat` and `delta` binary downloads from ephemeral environment config
- Remove `uv` and `uvx` binary downloads from ephemeral environment config

## Test plan

- [ ] Verify chezmoi apply works on ephemeral environments without these binaries
- [ ] Confirm these tools are available through other means (e.g., Homebrew or already removed from requirements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)