### PR TITLE
refactor(chezmoi): remove eza, fd, rg, sd, zoxide from ephemeral binaries

### DIFF
--- a/chezmoi/.chezmoiexternal.toml.tmpl
+++ b/chezmoi/.chezmoiexternal.toml.tmpl
@@ -15,6 +15,24 @@
   refreshPeriod = "168h"
 
 {{- if .is_ephemeral }}
+{{- if ne .chezmoi.os "darwin" }}
+[".local/bin/eza"]
+  type = "archive-file"
+  url = "{{ gitHubLatestReleaseAssetURL "eza-community/eza" (printf "eza_%s-%s.tar.gz" .arch .os) }}"
+  path = "eza"
+  stripComponents = 1
+  executable = true
+  refreshPeriod = "168h"
+{{- end }}
+
+[".local/bin/fd"]
+  type = "archive-file"
+  url = "{{ gitHubLatestReleaseAssetURL "sharkdp/fd" (printf "fd-*-%s-%s.tar.gz" .arch .os) }}"
+  path = "fd"
+  stripComponents = 1
+  executable = true
+  refreshPeriod = "168h"
+
 [".local/bin/fzf"]
   type = "archive-file"
   url = "{{ gitHubLatestReleaseAssetURL "junegunn/fzf" (printf "fzf-*-%s_%s.tar.gz" .chezmoi.os .chezmoi.arch) }}"
@@ -22,9 +40,32 @@
   executable = true
   refreshPeriod = "168h"
 
+[".local/bin/rg"]
+  type = "archive-file"
+  url = "{{ gitHubLatestReleaseAssetURL "BurntSushi/ripgrep" (printf "ripgrep-*-%s-*-%s*.tar.gz" .arch .chezmoi.os) }}"
+  path = "rg"
+  stripComponents = 1
+  executable = true
+  refreshPeriod = "168h"
+
+[".local/bin/sd"]
+  type = "archive-file"
+  url = "{{ gitHubLatestReleaseAssetURL "chmln/sd" (printf "sd-*-%s-*-%s*.tar.gz" .arch .chezmoi.os) }}"
+  path = "sd"
+  stripComponents = 1
+  executable = true
+  refreshPeriod = "168h"
+
 [".local/bin/yq"]
   type = "file"
   url = "{{ gitHubLatestReleaseAssetURL "mikefarah/yq" (printf "yq_%s_%s" .chezmoi.os .chezmoi.arch) }}"
+  executable = true
+  refreshPeriod = "168h"
+
+[".local/bin/zoxide"]
+  type = "archive-file"
+  url = "{{ gitHubLatestReleaseAssetURL "ajeetdsouza/zoxide" (printf "zoxide-*-%s-*-%s*.tar.gz" .arch .chezmoi.os) }}"
+  path = "zoxide"
   executable = true
   refreshPeriod = "168h"
 {{- end }}

--- a/chezmoi/.chezmoiexternal.toml.tmpl
+++ b/chezmoi/.chezmoiexternal.toml.tmpl
@@ -15,6 +15,22 @@
   refreshPeriod = "168h"
 
 {{- if .is_ephemeral }}
+[".local/bin/bat"]
+  type = "archive-file"
+  url = "{{ gitHubLatestReleaseAssetURL "sharkdp/bat" (printf "bat-*-%s-%s.tar.gz" .arch .os) }}"
+  path = "bat"
+  stripComponents = 1
+  executable = true
+  refreshPeriod = "168h"
+
+[".local/bin/delta"]
+  type = "archive-file"
+  url = "{{ gitHubLatestReleaseAssetURL "dandavison/delta" (printf "delta-*-%s-%s.tar.gz" .arch .os) }}"
+  path = "delta"
+  stripComponents = 1
+  executable = true
+  refreshPeriod = "168h"
+
 {{- if ne .chezmoi.os "darwin" }}
 [".local/bin/eza"]
   type = "archive-file"

--- a/chezmoi/.chezmoiexternal.toml.tmpl
+++ b/chezmoi/.chezmoiexternal.toml.tmpl
@@ -15,24 +15,6 @@
   refreshPeriod = "168h"
 
 {{- if .is_ephemeral }}
-{{- if ne .chezmoi.os "darwin" }}
-[".local/bin/eza"]
-  type = "archive-file"
-  url = "{{ gitHubLatestReleaseAssetURL "eza-community/eza" (printf "eza_%s-%s.tar.gz" .arch .os) }}"
-  path = "eza"
-  stripComponents = 1
-  executable = true
-  refreshPeriod = "168h"
-{{- end }}
-
-[".local/bin/fd"]
-  type = "archive-file"
-  url = "{{ gitHubLatestReleaseAssetURL "sharkdp/fd" (printf "fd-*-%s-%s.tar.gz" .arch .os) }}"
-  path = "fd"
-  stripComponents = 1
-  executable = true
-  refreshPeriod = "168h"
-
 [".local/bin/fzf"]
   type = "archive-file"
   url = "{{ gitHubLatestReleaseAssetURL "junegunn/fzf" (printf "fzf-*-%s_%s.tar.gz" .chezmoi.os .chezmoi.arch) }}"
@@ -40,32 +22,9 @@
   executable = true
   refreshPeriod = "168h"
 
-[".local/bin/rg"]
-  type = "archive-file"
-  url = "{{ gitHubLatestReleaseAssetURL "BurntSushi/ripgrep" (printf "ripgrep-*-%s-*-%s*.tar.gz" .arch .chezmoi.os) }}"
-  path = "rg"
-  stripComponents = 1
-  executable = true
-  refreshPeriod = "168h"
-
-[".local/bin/sd"]
-  type = "archive-file"
-  url = "{{ gitHubLatestReleaseAssetURL "chmln/sd" (printf "sd-*-%s-*-%s*.tar.gz" .arch .chezmoi.os) }}"
-  path = "sd"
-  stripComponents = 1
-  executable = true
-  refreshPeriod = "168h"
-
 [".local/bin/yq"]
   type = "file"
   url = "{{ gitHubLatestReleaseAssetURL "mikefarah/yq" (printf "yq_%s_%s" .chezmoi.os .chezmoi.arch) }}"
-  executable = true
-  refreshPeriod = "168h"
-
-[".local/bin/zoxide"]
-  type = "archive-file"
-  url = "{{ gitHubLatestReleaseAssetURL "ajeetdsouza/zoxide" (printf "zoxide-*-%s-*-%s*.tar.gz" .arch .chezmoi.os) }}"
-  path = "zoxide"
   executable = true
   refreshPeriod = "168h"
 {{- end }}


### PR DESCRIPTION
## Summary

- Remove `eza`, `fd`, `rg`, `sd`, `zoxide` binary downloads for ephemeral environments
- Keep `fzf` and `yq` as the remaining ephemeral binaries

## Test plan

- [ ] Verify chezmoi apply works on ephemeral environment
- [ ] Confirm removed tools are available via other means (e.g. Homebrew or pre-installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)