### PR TITLE
refactor(chezmoi): trim ephemeral env setup

### DIFF
--- a/chezmoi/.chezmoiexternal.toml.tmpl
+++ b/chezmoi/.chezmoiexternal.toml.tmpl
@@ -15,57 +15,10 @@
   refreshPeriod = "168h"
 
 {{- if .is_ephemeral }}
-{{- if ne .chezmoi.os "darwin" }}
-[".local/bin/eza"]
-  type = "archive-file"
-  url = "{{ gitHubLatestReleaseAssetURL "eza-community/eza" (printf "eza_%s-%s.tar.gz" .arch .os) }}"
-  path = "eza"
-  stripComponents = 1
-  executable = true
-  refreshPeriod = "168h"
-{{- end }}
-
-[".local/bin/fd"]
-  type = "archive-file"
-  url = "{{ gitHubLatestReleaseAssetURL "sharkdp/fd" (printf "fd-*-%s-%s.tar.gz" .arch .os) }}"
-  path = "fd"
-  stripComponents = 1
-  executable = true
-  refreshPeriod = "168h"
-
 [".local/bin/fzf"]
   type = "archive-file"
   url = "{{ gitHubLatestReleaseAssetURL "junegunn/fzf" (printf "fzf-*-%s_%s.tar.gz" .chezmoi.os .chezmoi.arch) }}"
   path = "fzf"
-  executable = true
-  refreshPeriod = "168h"
-
-[".local/bin/rg"]
-  type = "archive-file"
-  url = "{{ gitHubLatestReleaseAssetURL "BurntSushi/ripgrep" (printf "ripgrep-*-%s-*-%s*.tar.gz" .arch .chezmoi.os) }}"
-  path = "rg"
-  stripComponents = 1
-  executable = true
-  refreshPeriod = "168h"
-
-[".local/bin/sd"]
-  type = "archive-file"
-  url = "{{ gitHubLatestReleaseAssetURL "chmln/sd" (printf "sd-*-%s-*-%s*.tar.gz" .arch .chezmoi.os) }}"
-  path = "sd"
-  stripComponents = 1
-  executable = true
-  refreshPeriod = "168h"
-
-[".local/bin/yq"]
-  type = "file"
-  url = "{{ gitHubLatestReleaseAssetURL "mikefarah/yq" (printf "yq_%s_%s" .chezmoi.os .chezmoi.arch) }}"
-  executable = true
-  refreshPeriod = "168h"
-
-[".local/bin/zoxide"]
-  type = "archive-file"
-  url = "{{ gitHubLatestReleaseAssetURL "ajeetdsouza/zoxide" (printf "zoxide-*-%s-*-%s*.tar.gz" .arch .chezmoi.os) }}"
-  path = "zoxide"
   executable = true
   refreshPeriod = "168h"
 {{- end }}

--- a/chezmoi/.chezmoiscripts/run_onchange_setup_antigravity.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_setup_antigravity.sh.tmpl
@@ -10,8 +10,10 @@ extensions=(
   https://github.com/obra/superpowers
   https://github.com/JuliusBrussee/caveman
   https://github.com/exa-labs/exa-mcp-server
+  {{ if not .is_ephemeral -}}
   https://github.com/gemini-cli-extensions/conductor
   https://github.com/gemini-cli-extensions/security
+  {{ end -}}
   https://github.com/gemini-cli-extensions/jules
 )
 for entry in "${extensions[@]}"; do


### PR DESCRIPTION
## Summary

- Remove eza, fd, rg, sd, yq, zoxide from ephemeral binary downloads (keep fzf only)
- Skip conductor and security extensions on ephemeral environments in antigravity setup

## Test plan

- [ ] Verify ephemeral env only downloads fzf
- [ ] Verify non-ephemeral env unaffected
- [ ] Verify antigravity setup skips conductor/security on ephemeral

🤖 Generated with [Claude Code](https://claude.com/claude-code)