### PR TITLE
refactor: Adjust brew installs, add tflint, run uv upgrades

### DIFF
--- a/chezmoi/.chezmoiscripts/run_before_brew_install.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_before_brew_install.sh.tmpl
@@ -175,7 +175,6 @@ cask "zoom"
 # dev
 cask "claude-code"
 cask "github"
-cask "terraform-linters/tap/tflint"
 cask "visual-studio-code"
 cask "wezterm"
 

--- a/chezmoi/.chezmoiscripts/run_before_brew_install.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_before_brew_install.sh.tmpl
@@ -91,9 +91,9 @@ brew "yarn"
 
 # python
 brew "uv"
-uv "pre-commit"
-uv "ruff"
-uv "ty"
+brew "pre-commit"
+brew "ruff"
+brew "ty"
 
 # work
 brew "awscli"
@@ -175,6 +175,7 @@ cask "zoom"
 # dev
 cask "claude-code"
 cask "github"
+cask "terraform-linters/tap/tflint"
 cask "visual-studio-code"
 cask "wezterm"
 

--- a/scripts/update-all.sh
+++ b/scripts/update-all.sh
@@ -6,3 +6,4 @@ export GITHUB_TOKEN
 trap 'unset GITHUB_TOKEN' EXIT
 
 chezmoi --refresh-externals apply
+uv tool upgrade --all


### PR DESCRIPTION
Switch pre-commit/ruff/ty entries to be installed via brew in the chezmoi brew script, add the terraform-linters tap cask for tflint, and append a uv tool upgrade step to scripts/update-all.sh so uv-managed tools are upgraded during updates. Changes affect chezmoi/.chezmoiscripts/run_before_brew_install.sh.tmpl and scripts/update-all.sh.