### PR TITLE
chore: remove mise npm

### DIFF
--- a/chezmoi/.chezmoiscripts/run_before_brew_install.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_before_brew_install.sh.tmpl
@@ -167,10 +167,10 @@ cask "rectangle"
 # web
 cask "adguard"
 cask "brave-browser"
-cask "microsoft-edge"
+# cask "microsoft-edge"  # seems to required sudo everytime...
 
 # communication
-cask "microsoft-auto-update" # for microsoft-teams
+cask "microsoft-auto-update"  # for microsoft-teams
 cask "microsoft-teams"
 cask "slack"
 cask "zoom"

--- a/chezmoi/.chezmoiscripts/run_onchange_after_agent_plugins.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_after_agent_plugins.sh.tmpl
@@ -2,8 +2,7 @@
 set -euo pipefail
 
 if command -v npm >/dev/null; then
-  npm install --global @colbymchenry/codegraph
-  npx --yes @colbymchenry/codegraph install --target opencode --location global
+  npx --yes @colbymchenry/codegraph install --yes --location global --target opencode
 fi
 
 if command -v rtk >/dev/null; then
@@ -12,6 +11,6 @@ if command -v rtk >/dev/null; then
     rtk init --global --auto-patch --hook-only;
   fi
   if command -v opencode >/dev/null; then
-    rtk init --global --opencode --auto-patch --hook-only;
+    rtk init --global --opencode;
   fi
 fi

--- a/chezmoi/private_dot_config/mise/config.toml
+++ b/chezmoi/private_dot_config/mise/config.toml
@@ -1,3 +1,2 @@
 [tools]
 java = "17"
-node = "lts"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Microsoft Edge Homebrew installation is now disabled; users requiring this browser must install it manually
* Agent plugin npm package installation process has been updated with a new installation method
* Development toolchain configuration has been updated: Java 17 is now configured and available; Node.js LTS has been removed from automatic installation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->