### PR TITLE
feat: migrate opencode TUI config into main opencode.json

### DIFF
--- a/chezmoi/.chezmoitemplates/opencode-tui.json
+++ b/chezmoi/.chezmoitemplates/opencode-tui.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://opencode.ai/tui.json",
+  "theme": "opencode",
+  "scroll_acceleration": {
+    "enabled": true
+  }
+}

--- a/chezmoi/.chezmoitemplates/opencode-tui.json
+++ b/chezmoi/.chezmoitemplates/opencode-tui.json
@@ -1,7 +1,11 @@
 {
   "$schema": "https://opencode.ai/tui.json",
   "theme": "opencode",
+  "mouse": true,
   "scroll_acceleration": {
+    "enabled": true
+  },
+  "attention": {
     "enabled": true
   }
 }

--- a/chezmoi/.chezmoitemplates/opencode-tui.json
+++ b/chezmoi/.chezmoitemplates/opencode-tui.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://opencode.ai/tui.json",
-  "attention.enabled": true,
-  "scroll_acceleration.enabled": true,
-  "theme": "opencode"
-}

--- a/chezmoi/.chezmoitemplates/opencode.json
+++ b/chezmoi/.chezmoitemplates/opencode.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "autoupdate": true,
   "formatter": true,
   "lsp": true,
   "model": "opencode/deepseek-v4-flash-free",
@@ -9,8 +8,7 @@
   "tui": {
     "scroll_acceleration": {
       "enabled": true
-    },
-    "diff_style": "auto"
+    }
   },
   "plugin": [
     "superpowers@git+https://github.com/obra/superpowers.git",

--- a/chezmoi/.chezmoitemplates/opencode.json
+++ b/chezmoi/.chezmoitemplates/opencode.json
@@ -4,12 +4,6 @@
   "lsp": true,
   "model": "opencode/deepseek-v4-flash-free",
   "small_model": "opencode/deepseek-v4-flash-free",
-  "theme": "opencode",
-  "tui": {
-    "scroll_acceleration": {
-      "enabled": true
-    }
-  },
   "plugin": [
     "superpowers@git+https://github.com/obra/superpowers.git",
     "@tarquinen/opencode-dcp",

--- a/chezmoi/.chezmoitemplates/opencode.json
+++ b/chezmoi/.chezmoitemplates/opencode.json
@@ -3,6 +3,7 @@
   "formatter": true,
   "lsp": true,
   "model": "opencode/deepseek-v4-flash-free",
+  "small_model": "opencode/deepseek-v4-flash-free",
   "compaction": {
     "prune": true
   },

--- a/chezmoi/.chezmoitemplates/opencode.json
+++ b/chezmoi/.chezmoitemplates/opencode.json
@@ -3,7 +3,9 @@
   "formatter": true,
   "lsp": true,
   "model": "opencode/deepseek-v4-flash-free",
-  "small_model": "opencode/deepseek-v4-flash-free",
+  "compaction": {
+    "prune": true
+  },
   "plugin": [
     "superpowers@git+https://github.com/obra/superpowers.git",
     "@tarquinen/opencode-dcp",

--- a/chezmoi/.chezmoitemplates/opencode.json
+++ b/chezmoi/.chezmoitemplates/opencode.json
@@ -4,14 +4,21 @@
   "formatter": true,
   "lsp": true,
   "model": "opencode/deepseek-v4-flash-free",
+  "small_model": "opencode/deepseek-v4-flash-free",
+  "theme": "opencode",
+  "tui": {
+    "scroll_acceleration": {
+      "enabled": true
+    },
+    "diff_style": "auto"
+  },
   "plugin": [
     "superpowers@git+https://github.com/obra/superpowers.git",
-    "@tarquinen/opencode-dcp@latest",
-    "openslimedit@latest",
+    "@tarquinen/opencode-dcp",
+    "openslimedit",
     "context-mode",
     "@zilliz/memsearch-opencode"
   ],
-  "small_model": "opencode/deepseek-v4-flash-free",
   "mcp": {
     "context-mode": {
       "type": "local",

--- a/chezmoi/private_dot_config/opencode/modify_tui.json
+++ b/chezmoi/private_dot_config/opencode/modify_tui.json
@@ -1,7 +1,0 @@
-{{- /* chezmoi:modify-template */ -}}
-{{- $current := dict -}}
-{{- if .chezmoi.stdin | trim -}}
-{{-   $current = fromJson .chezmoi.stdin -}}
-{{- end -}}
-{{- $chezmoi := includeTemplate "opencode-tui.json" . | fromJson -}}
-{{ mergeOverwrite $current $chezmoi | toPrettyJson }}

--- a/chezmoi/private_dot_config/opencode/modify_tui.json
+++ b/chezmoi/private_dot_config/opencode/modify_tui.json
@@ -1,0 +1,7 @@
+{{- /* chezmoi:modify-template */ -}}
+{{- $current := dict -}}
+{{- if .chezmoi.stdin | trim -}}
+{{-   $current = fromJson .chezmoi.stdin -}}
+{{- end -}}
+{{- $chezmoi := includeTemplate "opencode-tui.json" . | fromJson -}}
+{{ mergeOverwrite $current $chezmoi | toPrettyJson }}


### PR DESCRIPTION
## Summary

- Move TUI settings (`theme`, `scroll_acceleration`, `diff_style`) from separate `opencode-tui.json` template into the `tui` key of the main `opencode.json`, per current opencode schema
- Remove deprecated `opencode-tui.json` template and `modify_tui.json` script
- Drop config keys that match defaults (`autoupdate: true`, `tui.diff_style: "auto"`)

## Test plan

- [ ] Run `chezmoi apply` and verify `~/.config/opencode/opencode.json` contains `tui.scroll_acceleration.enabled: true` and `theme: "opencode"`
- [ ] Confirm `~/.config/opencode/tui.json` is no longer managed by chezmoi

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the app’s default TUI settings, including a new theme and smoother scrolling behavior.
  * Simplified the available configuration by removing some legacy preset values and template handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->