### PR TITLE
feat: force autoUpdate on all claude plugin marketplaces

### DIFF
--- a/chezmoi/private_dot_claude/modify_settings.json
+++ b/chezmoi/private_dot_claude/modify_settings.json
@@ -3,10 +3,10 @@
 {{- if .chezmoi.stdin | trim -}}
 {{-   $current = fromJson .chezmoi.stdin -}}
 {{- end -}}
-{{- $chezmoi := includeTemplate "claude-settings.json" . | fromJson -}}
-{{- $merged := mergeOverwrite $current $chezmoi -}}
-{{- if hasKey $current "extraKnownMarketplaces" -}}
-{{-   range $name, $marketplace := $current.extraKnownMarketplaces -}}
+{{- $template := includeTemplate "claude-settings.json" . | fromJson -}}
+{{- $merged := mergeOverwrite $current $template -}}
+{{- if hasKey $merged "extraKnownMarketplaces" -}}
+{{-   range $name, $marketplace := $merged.extraKnownMarketplaces -}}
 {{-     $merged = setValueAtPath (list "extraKnownMarketplaces" $name "autoUpdate") true $merged -}}
 {{-   end -}}
 {{- end -}}

--- a/chezmoi/private_dot_claude/modify_settings.json
+++ b/chezmoi/private_dot_claude/modify_settings.json
@@ -4,4 +4,10 @@
 {{-   $current = fromJson .chezmoi.stdin -}}
 {{- end -}}
 {{- $chezmoi := includeTemplate "claude-settings.json" . | fromJson -}}
-{{ mergeOverwrite $current $chezmoi | toPrettyJson }}
+{{- $merged := mergeOverwrite $current $chezmoi -}}
+{{- if hasKey $current "extraKnownMarketplaces" -}}
+{{-   range $name, $marketplace := $current.extraKnownMarketplaces -}}
+{{-     $merged = setValueAtPath (list "extraKnownMarketplaces" $name "autoUpdate") true $merged -}}
+{{-   end -}}
+{{- end -}}
+{{ $merged | toPrettyJson }}

--- a/chezmoi/private_dot_config/mcp/modify_mcp_servers.json
+++ b/chezmoi/private_dot_config/mcp/modify_mcp_servers.json
@@ -3,5 +3,5 @@
 {{- if .chezmoi.stdin | trim -}}
 {{-   $current = fromJson .chezmoi.stdin -}}
 {{- end -}}
-{{- $chezmoi := includeTemplate "mcp_servers.json" . | fromJson -}}
-{{ mergeOverwrite $current $chezmoi | toPrettyJson }}
+{{- $template := includeTemplate "mcp_servers.json" . | fromJson -}}
+{{ mergeOverwrite $current $template | toPrettyJson }}

--- a/chezmoi/private_dot_config/opencode/modify_opencode.json
+++ b/chezmoi/private_dot_config/opencode/modify_opencode.json
@@ -3,5 +3,5 @@
 {{- if .chezmoi.stdin | trim -}}
 {{-   $current = fromJson .chezmoi.stdin -}}
 {{- end -}}
-{{- $chezmoi := includeTemplate "opencode.json" . | fromJson -}}
-{{ mergeOverwrite $current $chezmoi | toPrettyJson }}
+{{- $template := includeTemplate "opencode.json" . | fromJson -}}
+{{ mergeOverwrite $current $template | toPrettyJson }}

--- a/chezmoi/private_dot_config/opencode/modify_tui.json
+++ b/chezmoi/private_dot_config/opencode/modify_tui.json
@@ -3,5 +3,5 @@
 {{- if .chezmoi.stdin | trim -}}
 {{-   $current = fromJson .chezmoi.stdin -}}
 {{- end -}}
-{{- $chezmoi := includeTemplate "opencode-tui.json" . | fromJson -}}
-{{ mergeOverwrite $current $chezmoi | toPrettyJson }}
+{{- $template := includeTemplate "opencode-tui.json" . | fromJson -}}
+{{ mergeOverwrite $current $template | toPrettyJson }}


### PR DESCRIPTION
## Summary
- The `claude plugin marketplace add` CLI has no flag to enable `autoUpdate`, so `modify_settings.json` now forces `autoUpdate: true` on every existing `extraKnownMarketplaces` entry on each `chezmoi apply`, regardless of how the CLI registered the marketplace name.

## Test plan
- [x] Verified template renders correctly via `chezmoi execute-template`, confirming `autoUpdate` is forced `true` for marketplaces not present in the base template (e.g. CLI-added ones) and overrides existing `false` values.
- [ ] Run `chezmoi apply` and confirm `~/.claude/settings.json` reflects `autoUpdate: true` for all marketplaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how settings are merged to ensure existing configuration is preserved more reliably while applying template defaults.
  * When marketplace entries include an `autoUpdate` preference, it’s now kept in the final rendered configuration so those settings reliably take effect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->