### PR TITLE
feat: add mattpocock skills, drop superpowers plugin

### DIFF
--- a/chezmoi/.chezmoiscripts/run_onchange_after_agent_plugins.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_after_agent_plugins.sh.tmpl
@@ -29,6 +29,8 @@ agents+=(claude-code)
 {{- end }}
 
 repo_skills=(
+  mattpocock/skills=setup-matt-pocock-skills,grill-with-docs,grilling,domain-modeling,to-prd,to-issues
+  mattpocock/skills=research,codebase-design,tdd,improve-codebase-architecture,diagnosing-bugs
   philschmid/mcp-cli=mcp-cli
 )
 for entry in "${repo_skills[@]}"; do

--- a/chezmoi/.chezmoiscripts/run_onchange_setup_claude.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_setup_claude.sh.tmpl
@@ -25,7 +25,6 @@ plugins=(
   caveman@caveman
   context-mode@context-mode
   memsearch@memsearch-plugins
-  superpowers@claude-plugins-official
 )
 for entry in "${plugins[@]}"; do
   claude plugin install "${entry}"

--- a/chezmoi/.chezmoitemplates/opencode.json
+++ b/chezmoi/.chezmoitemplates/opencode.json
@@ -8,7 +8,6 @@
     "prune": true
   },
   "plugin": [
-    "superpowers@git+https://github.com/obra/superpowers.git",
     "@tarquinen/opencode-dcp",
     "openslimedit",
     "context-mode",


### PR DESCRIPTION
## Summary
- Add mattpocock/skills entries (setup, docs, grilling, domain-modeling, prd/issue drafting, research, codebase-design, tdd, architecture, bug-diagnosing) to the agent skills install list
- Drop `superpowers@claude-plugins-official` from claude plugin install list
- Drop superpowers from opencode plugin list

## Test plan
- [x] pre-commit hooks pass
- [ ] `chezmoi apply` picks up new skill entries and installs mattpocock skills correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded the available skill sets configured for repository automation, adding more options for setup, documentation, research, architecture, debugging, and planning workflows.
  * Updated local AI tool/plugin setup to use a streamlined plugin list.
  * Removed one previously included plugin from the OpenCode configuration, keeping the remaining integrations intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->