### PR TITLE
feat: manage global memsearch config via chezmoi

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,6 +62,7 @@ repos:
     rev: v0.9.3
     hooks:
       - id: taplo-format
+        exclude: /modify_.*\.toml$
 
   - repo: https://github.com/google/yamlfmt
     rev: v0.21.0

--- a/chezmoi/.chezmoitemplates/memsearch_config.toml
+++ b/chezmoi/.chezmoitemplates/memsearch_config.toml
@@ -1,0 +1,13 @@
+[embedding]
+provider = "onnx"
+
+[reranker]
+model = "Alibaba-NLP/gte-reranker-modernbert-base"
+
+[plugins.claude-code.user_profile]
+enabled = true
+output_file = "~/.memsearch/USER.md"
+
+[plugins.opencode.user_profile]
+enabled = true
+output_file = "~/.memsearch/USER.md"

--- a/chezmoi/private_dot_memsearch/modify_config.toml
+++ b/chezmoi/private_dot_memsearch/modify_config.toml
@@ -1,0 +1,8 @@
+{{- /* chezmoi:modify-template */ -}}
+{{- $current := dict -}}
+{{- if .chezmoi.stdin | trim -}}
+{{-   $current = fromToml .chezmoi.stdin -}}
+{{- end -}}
+{{- $template := includeTemplate "memsearch_config.toml" . | fromToml -}}
+{{- $merged := mergeOverwrite $current $template -}}
+{{ $merged | toToml }}


### PR DESCRIPTION
## Summary
- Add `.chezmoitemplates/memsearch_config.toml` — global onnx embedding, cross-encoder reranker, and `user_profile` maintenance (claude-code + opencode) writing to a shared `~/.memsearch/USER.md`.
- Add `private_dot_memsearch/modify_config.toml` to merge the template into `~/.memsearch/config.toml` on `chezmoi apply`, preserving any existing local overrides.
- Exclude `modify_*.toml` from taplo-format (Go template syntax, not valid standalone TOML).

## Test plan
- [x] Verified merge behavior in isolated chezmoi source/destination dirs (fresh install + existing config both produce correct merged TOML)
- [x] `chezmoi execute-template` resolves template correctly
- [x] pre-commit passes with taplo exclusion
- [ ] `chezmoi apply` on a real machine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new memsearch setup with default embedding and reranking settings.
  * Enabled user profile output for supported assistant integrations, saving profiles to a local markdown file.

* **Chores**
  * Updated formatting checks to skip certain TOML files used for generated or customized configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->