### PR TITLE
feat: add global memory (OKF) instructions and uv sandbox path

### DIFF
--- a/chezmoi/.chezmoitemplates/AGENTS.md
+++ b/chezmoi/.chezmoitemplates/AGENTS.md
@@ -36,6 +36,37 @@
 - Do not duplicate information between the two files. Reference
   `README.md` for project context.
 
+## Global Memory
+
+Durable, cross-project knowledge lives under `~/.memory/`, separate
+from per-project automemory.
+Structured as an [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+bundle: `index.md` lists topic files; every other `.md` file needs
+YAML frontmatter (at least `type`).
+
+Rules:
+
+- At session start, read `~/.memory/index.md`; load topic files
+  only when relevant.
+- Write durable, cross-project learnings to a matching topic file
+  with frontmatter (create one if none fits) and add it to
+  `index.md`. Project-specific info belongs in automemory instead.
+- Organize by topic freely, no fixed taxonomy. Split files that
+  grow unwieldy or unfocused.
+- `~/.memsearch/USER.md` is a related, read-only reference
+  maintained by memsearch — don't edit it or merge it into
+  `~/.memory/`.
+- Maintain as you go: when editing a topic file, fix or remove
+  entries you find stale, wrong, or superseded. Keep `index.md` in
+  sync with what actually exists on disk.
+- Re-index after edits so search stays current:
+
+  ```sh
+  uvx --from 'memsearch[onnx]' memsearch index ~/.memory \
+    --collection global-memory \
+    --description "global cross-project memory"
+  ```
+
 ## Code Quality
 
 - Follow existing patterns and conventions in codebase.

--- a/chezmoi/.chezmoitemplates/AGENTS.md
+++ b/chezmoi/.chezmoitemplates/AGENTS.md
@@ -59,13 +59,6 @@ Rules:
 - Maintain as you go: when editing a topic file, fix or remove
   entries you find stale, wrong, or superseded. Keep `index.md` in
   sync with what actually exists on disk.
-- Re-index after edits so search stays current:
-
-  ```sh
-  uvx --from 'memsearch[onnx]' memsearch index ~/.memory \
-    --collection global-memory \
-    --description "global cross-project memory"
-  ```
 
 ## Code Quality
 

--- a/chezmoi/.chezmoitemplates/claude-settings.json
+++ b/chezmoi/.chezmoitemplates/claude-settings.json
@@ -61,6 +61,7 @@
         "~/.cargo/registry",
         "~/.gradle",
         "~/.local/lib",
+        "~/.local/share/uv",
         "~/.m2",
         "~/.npm",
         "~/.yarn",


### PR DESCRIPTION
## Summary
- Documents a cross-project, cross-agent-CLI memory bundle under `~/.memory/`, structured per the Open Knowledge Format spec, with rules for maintaining and re-indexing it via memsearch.
- Allowlists `~/.local/share/uv` for sandboxed writes since `uvx` needs it to create temp files during tool invocation.

## Test plan
- [ ] `chezmoi apply` renders both files without diff drift
- [ ] `uvx --from 'memsearch[onnx]' memsearch index ~/.memory --collection global-memory` runs without sandbox permission errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for managing a global memory area, including how to organize topic notes, keep summaries in sync, and refresh indexes after updates.
* **Chores**
  * Expanded the allowed write locations in the sandbox configuration to support an additional local storage path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->