### PR TITLE
chore: remove unused Claude Code plugins, restore caveman statusline

### DIFF
--- a/chezmoi/.chezmoiscripts/run_onchange_setup_claude.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_setup_claude.sh.tmpl
@@ -10,7 +10,6 @@ fi
 marketplaces=(
   anthropics/claude-plugins-official
   JuliusBrussee/caveman
-  mksglu/context-mode
   zilliztech/memsearch
 )
 for entry in "${marketplaces[@]}"; do
@@ -20,16 +19,11 @@ done
 plugins=(
   claude-code-setup@claude-plugins-official
   claude-md-management@claude-plugins-official
-  code-simplifier@claude-plugins-official
   commit-commands@claude-plugins-official
-  feature-dev@claude-plugins-official
   gopls-lsp@claude-plugins-official
-  pr-review-toolkit@claude-plugins-official
   pyright-lsp@claude-plugins-official
-  security-guidance@claude-plugins-official
   typescript-lsp@claude-plugins-official
   caveman@caveman
-  context-mode@context-mode
   memsearch@memsearch-plugins
 )
 for entry in "${plugins[@]}"; do

--- a/chezmoi/.chezmoitemplates/claude-settings.json
+++ b/chezmoi/.chezmoitemplates/claude-settings.json
@@ -74,7 +74,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "npx --yes context-mode statusline"
+    "command": "bash ~/.claude/hooks/caveman-statusline.sh"
   },
   "worktree": {
     "baseRef": "fresh"


### PR DESCRIPTION
## Summary
- Removed context-mode, security-guidance, pr-review-toolkit, feature-dev, code-simplifier plugins — company MCP policy blocks direct tool use, so these added standing token cost (skill/agent descriptions, hooks) with no realized benefit.
- Restored caveman's own statusline script in place of context-mode's `npx --yes context-mode statusline`.

## Test plan
- [x] `bash ~/.claude/hooks/caveman-statusline.sh` runs clean, outputs badge
- [x] `chezmoi/.chezmoitemplates/claude-settings.json` and `run_onchange_setup_claude.sh.tmpl` in sync with live `~/.claude/settings.json`