### PR TITLE
feat: share memsearch memory globally via MEMSEARCH_DIR

### DIFF
--- a/chezmoi/.chezmoitemplates/memsearch_config.toml
+++ b/chezmoi/.chezmoitemplates/memsearch_config.toml
@@ -6,6 +6,7 @@ model = "Alibaba-NLP/gte-reranker-modernbert-base"
 
 [plugins.claude-code.project_review]
 enabled = true
+output_file = "~/.memsearch/PROJECT.md"
 
 [plugins.claude-code.user_profile]
 enabled = true
@@ -16,6 +17,7 @@ enabled = true
 
 [plugins.opencode.project_review]
 enabled = true
+output_file = "~/.memsearch/PROJECT.md"
 
 [plugins.opencode.user_profile]
 enabled = true

--- a/chezmoi/private_dot_config/zsh/dot_zshenv
+++ b/chezmoi/private_dot_config/zsh/dot_zshenv
@@ -29,3 +29,5 @@ if [[ -f "${cert_file}" ]]; then
   export REQUESTS_CA_BUNDLE=${cert_file}
   export SSL_CERT_FILE=${cert_file}
 fi
+
+export MEMSEARCH_DIR=${HOME}/.memsearch


### PR DESCRIPTION
## Summary
- Export `MEMSEARCH_DIR=${HOME}/.memsearch` in `dot_zshenv` so the Claude Code and Codex memsearch plugin hooks share one memory directory and Milvus collection across all projects, instead of one per repo.
- Point `plugins.claude-code.project_review.output_file` and `plugins.opencode.project_review.output_file` at the same global `~/.memsearch/PROJECT.md`, matching `project_review`'s input journal (which is already global by default under a shared `MEMSEARCH_DIR`).

## Test plan
- [ ] `chezmoi apply` and confirm `echo $MEMSEARCH_DIR` resolves to `~/.memsearch` in a new shell
- [ ] Start a Claude Code session in a couple of different repos and confirm memory journals land in `~/.memsearch/memory/`
- [ ] Confirm `memsearch config get plugins.claude-code.project_review.output_file` resolves to `~/.memsearch/PROJECT.md`
- [ ] Note: OpenCode's plugin hardcodes a per-project `.memsearch` dir and does not read `MEMSEARCH_DIR`, so OpenCode memory remains project-scoped by design

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configured project reviews for Claude Code and OpenCode to save results to `~/.memsearch/PROJECT.md`.
  * Added the `MEMSEARCH_DIR` environment variable, pointing to the user’s `~/.memsearch` directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->