### PR TITLE
fix: remove-memsearch-project-output-file

### DIFF
--- a/chezmoi/.chezmoitemplates/memsearch_config.toml
+++ b/chezmoi/.chezmoitemplates/memsearch_config.toml
@@ -6,7 +6,6 @@ model = "Alibaba-NLP/gte-reranker-modernbert-base"
 
 [plugins.claude-code.project_review]
 enabled = true
-output_file = "~/.memsearch/PROJECT.md"
 
 [plugins.claude-code.user_profile]
 enabled = true
@@ -17,7 +16,6 @@ enabled = true
 
 [plugins.opencode.project_review]
 enabled = true
-output_file = "~/.memsearch/PROJECT.md"
 
 [plugins.opencode.user_profile]
 enabled = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project review plugin configuration by removing unsupported output file settings.
  * Project review plugins now use their default output behavior while remaining enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->