### PR TITLE
fix(memsearch): global-project-review

### DIFF
--- a/chezmoi/.chezmoitemplates/memsearch_config.toml
+++ b/chezmoi/.chezmoitemplates/memsearch_config.toml
@@ -6,6 +6,7 @@ model = "Alibaba-NLP/gte-reranker-modernbert-base"
 
 [plugins.claude-code.project_review]
 enabled = true
+output_file = "~/.memsearch/PROJECT.md"
 
 [plugins.claude-code.user_profile]
 enabled = true
@@ -16,6 +17,7 @@ enabled = true
 
 [plugins.opencode.project_review]
 enabled = true
+output_file = "~/.memsearch/PROJECT.md"
 
 [plugins.opencode.user_profile]
 enabled = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project review output is now consistently saved to `~/.memsearch/PROJECT.md` across supported integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->