### PR TITLE
feat(claude): add mempalace plugin

### DIFF
--- a/chezmoi/.chezmoiscripts/run_onchange_after_setup_claude.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_after_setup_claude.sh.tmpl
@@ -11,6 +11,7 @@ marketplaces=(
   anthropics/claude-plugins-official
   JuliusBrussee/caveman
   mattpocock/skills
+  MemPalace/mempalace
   zilliztech/memsearch
 )
 for entry in "${marketplaces[@]}"; do
@@ -25,6 +26,7 @@ plugins=(
   typescript-lsp@claude-plugins-official
   caveman@caveman
   mattpocock-skills@mattpocock
+  mempalace@mempalace
   memsearch@memsearch-plugins
 )
 for entry in "${plugins[@]}"; do


### PR DESCRIPTION
## Summary

- Add `MemPalace/mempalace` marketplace to chezmoi Claude setup script
- Add `mempalace@mempalace` plugin to auto-install list

## Test plan

- [ ] `chezmoi apply` installs mempalace plugin
- [ ] `/mempalace:*` skills available after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MemPalace marketplace registration to the Claude setup flow on macOS.
  * Added automatic installation of the MemPalace plugin during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->