### PR TITLE
fix: gitignore mempalace

### DIFF
--- a/chezmoi/private_dot_config/git/ignore.tmpl
+++ b/chezmoi/private_dot_config/git/ignore.tmpl
@@ -5,9 +5,15 @@
 !.env.example
 .envrc
 
+*.bak
+.cache
+*.lock
+.tmp
+
 # python
-.venv
 __pycache__
+*.py[codz]
+.venv
 
 # node
 node_modules

--- a/chezmoi/private_dot_config/git/ignore.tmpl
+++ b/chezmoi/private_dot_config/git/ignore.tmpl
@@ -1,6 +1,23 @@
 {{- template "gitignore" . }}
 
+.env
+.env.*
+!.env.example
+.envrc
+
+# python
+.venv
+__pycache__
+
+# node
+node_modules
+
+# claude
+**/.claude/.cc-writes/
 **/.claude/settings.local.json
 .codebase-memory
 .memsearch
 .scratch
+
+entities.json
+mempalace.yaml


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded default Git ignore rules to cover environment files, caches, lock and temporary files.
  * Added common Python and Node.js exclusions.
  * Broadened exclusions for Claude-related settings, memory, scratch files, and directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->