### PR TITLE
feat: add daily-summary skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Loaded automatically as `okf@skills-dir` on session start — no install step.
 Current plugins:
 
 - `okf` — OKF skill + SessionEnd hook that distills memsearch journals into the `~/wiki` OKF bundle
+- `daily-summary` — standup digest skill that groups the day's memsearch activity log by repository
 
 ## License
 

--- a/chezmoi/private_dot_agents/skills/daily-summary/SKILL.md
+++ b/chezmoi/private_dot_agents/skills/daily-summary/SKILL.md
@@ -12,10 +12,10 @@ the memsearch memory log for the requested date.
 
 ## Steps
 
-1. **Date** — use `$ARGUMENTS` if provided; default to yesterday in the local
-   timezone if omitted. Validate the value is a calendar-valid `YYYY-MM-DD`
-   (digits only, no path separators or other characters). Reject and report any
-   malformed input before proceeding.
+1. **Date** — use `$ARGUMENTS` if provided and non-empty; treat absent or
+   empty as omitted and default to yesterday. Validate the value is a
+   calendar-valid `YYYY-MM-DD`. Reject and report any malformed input before
+   proceeding.
 
 2. **Load** — read `~/.memsearch/memory/<date>.md`. Stop and tell the user if the file is missing.
 
@@ -25,9 +25,10 @@ the memsearch memory log for the requested date.
    task is assigned.
 
 4. **Output** the standup in a fenced code block. No preamble. One bullet per
-   distinct task. Each bullet ≤10 words. Under each repo, nest sub-tasks (one
-   level deep) only when they are genuinely distinct steps of the parent, not
-   just elaborations. Skip sessions with no substantive outcome.
+   distinct task. Each bullet ≤12 words. Under each task, nest sub-tasks one
+   level deep only when they are genuinely distinct steps of the parent, not
+   just elaborations. Skip sessions where all entries are reads, searches, or
+   investigations with no resulting change or decision.
 
 ````text
 ```

--- a/chezmoi/private_dot_agents/skills/daily-summary/SKILL.md
+++ b/chezmoi/private_dot_agents/skills/daily-summary/SKILL.md
@@ -7,28 +7,22 @@ argument-hint: "[YYYY-MM-DD]"
 
 # Daily Summary
 
-Produce a **standup** — a repo-grouped bullet digest of the day's work — from
-the memsearch memory log for the requested date.
+Produce a **standup** from the memsearch memory log for the requested date.
 
 ## Steps
 
-1. **Date** — use `$ARGUMENTS` if provided and non-empty; treat absent or
-   empty as omitted and default to yesterday. Validate the value is a
-   calendar-valid `YYYY-MM-DD`. Reject and report any malformed input before
-   proceeding.
+1. **Date** — use `$ARGUMENTS` if non-empty; default to yesterday. Validate
+   `YYYY-MM-DD`; reject with an error message on malformed input.
 
 2. **Load** — read `~/.memsearch/memory/<date>.md`. Stop and tell the user if the file is missing.
 
-3. **Map** — identify every repo mentioned; assign each task to the repo where
-   the code change happened. Tasks not tied to any specific repo go under
-   `Other`. Done when every distinct repo is identified and every substantive
-   task is assigned.
+3. **Map** — assign each task to the repo where the change happened. Tasks
+   with no repo go under `Other`.
 
 4. **Output** the standup in a fenced code block. No preamble. One bullet per
-   distinct task. Each bullet ≤12 words. Under each task, nest sub-tasks one
-   level deep only when they are genuinely distinct steps of the parent, not
-   just elaborations. Skip sessions where all entries are reads, searches, or
-   investigations with no resulting change or decision.
+   task, ≤12 words. Under each task, nest sub-tasks one level deep only when
+   they are genuinely distinct steps, not elaborations. Skip sessions with only
+   exploration and no resulting change or decision.
 
 ````text
 ```

--- a/chezmoi/private_dot_agents/skills/daily-summary/SKILL.md
+++ b/chezmoi/private_dot_agents/skills/daily-summary/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: daily-summary
+description: Daily standup digest from memsearch activity logs, grouped by repo.
+disable-model-invocation: true
+argument-hint: "<YYYY-MM-DD>"
+---
+
+# Daily Summary
+
+Produce a **standup** — a repo-grouped bullet digest of the day's work — from
+the memsearch memory log for the requested date.
+
+## Steps
+
+1. **Date** — use `args` (format `YYYY-MM-DD`); default to yesterday if omitted.
+
+2. **Load** — read `~/.memsearch/memory/<date>.md`. Stop and tell the user if the file is missing.
+
+3. **Map** — identify every repo mentioned; assign each task to the repo where
+   the code change happened. Done when every distinct repo is identified and
+   every substantive task is assigned.
+
+4. **Output** the standup in a fenced code block. No preamble. One bullet per
+   distinct task. Each bullet ≤10 words. Nest sub-tasks only when they are
+   genuinely distinct steps of the parent, not just elaborations. Max 2 levels.
+   Skip sessions with no substantive outcome.
+
+````text
+```
+- `<repo-path>`
+  - <task>
+    - <sub-task if distinct>
+  - <task>
+- `<repo-path-2>`
+  - <task>
+```
+````

--- a/chezmoi/private_dot_agents/skills/daily-summary/SKILL.md
+++ b/chezmoi/private_dot_agents/skills/daily-summary/SKILL.md
@@ -2,7 +2,7 @@
 name: daily-summary
 description: Daily standup digest from memsearch activity logs, grouped by repo.
 disable-model-invocation: true
-argument-hint: "<YYYY-MM-DD>"
+argument-hint: "[YYYY-MM-DD]"
 ---
 
 # Daily Summary
@@ -12,18 +12,22 @@ the memsearch memory log for the requested date.
 
 ## Steps
 
-1. **Date** — use `args` (format `YYYY-MM-DD`); default to yesterday if omitted.
+1. **Date** — use `$ARGUMENTS` if provided; default to yesterday in the local
+   timezone if omitted. Validate the value is a calendar-valid `YYYY-MM-DD`
+   (digits only, no path separators or other characters). Reject and report any
+   malformed input before proceeding.
 
 2. **Load** — read `~/.memsearch/memory/<date>.md`. Stop and tell the user if the file is missing.
 
 3. **Map** — identify every repo mentioned; assign each task to the repo where
-   the code change happened. Done when every distinct repo is identified and
-   every substantive task is assigned.
+   the code change happened. Tasks not tied to any specific repo go under
+   `Other`. Done when every distinct repo is identified and every substantive
+   task is assigned.
 
 4. **Output** the standup in a fenced code block. No preamble. One bullet per
-   distinct task. Each bullet ≤10 words. Nest sub-tasks only when they are
-   genuinely distinct steps of the parent, not just elaborations. Max 2 levels.
-   Skip sessions with no substantive outcome.
+   distinct task. Each bullet ≤10 words. Under each repo, nest sub-tasks (one
+   level deep) only when they are genuinely distinct steps of the parent, not
+   just elaborations. Skip sessions with no substantive outcome.
 
 ````text
 ```
@@ -33,5 +37,7 @@ the memsearch memory log for the requested date.
   - <task>
 - `<repo-path-2>`
   - <task>
+- Other
+  - <task not tied to a repo>
 ```
 ````

--- a/chezmoi/private_dot_claude/skills/symlink_daily-summary
+++ b/chezmoi/private_dot_claude/skills/symlink_daily-summary
@@ -1,0 +1,1 @@
+../../.agents/skills/daily-summary


### PR DESCRIPTION
## Summary

- Add `daily-summary` skill that produces a repo-grouped standup digest from memsearch activity logs
- Takes an optional `YYYY-MM-DD` date argument (defaults to yesterday)
- Outputs work grouped by repo as a fenced code block with ≤10-word bullets, max 2 nesting levels
- Marked `disable-model-invocation: true` — user-invoked only, zero token cost unless called
- Symlinked from `private_dot_claude/skills/` so it's available in Claude Code sessions

## Test plan

- [ ] Run `/daily-summary` with no args → produces yesterday's standup
- [ ] Run `/daily-summary 2026-07-16` → produces that date's standup grouped by repo
- [ ] Missing date file → skill stops with clear message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a daily summary skill that generates a repo-grouped standup digest from your daily memory log.
  * Lets you choose a specific `YYYY-MM-DD` date (defaults to yesterday).
  * Validates the date format and shows a clear message if the log for that date is missing.
  * Groups tasks by repos referenced in the log, with a fallback for uncategorized items.
  * Outputs results as concise bullet points, skipping sessions without substantive outcomes.
  * Exposed the skill via the Claude skills directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->