### PR TITLE
refactor(okf): use --bare mode in wiki maintenance hook

### DIFF
--- a/chezmoi/private_dot_agents/skills/okf/hooks/executable_okf-wiki-maintenance.sh
+++ b/chezmoi/private_dot_agents/skills/okf/hooks/executable_okf-wiki-maintenance.sh
@@ -58,7 +58,7 @@ if printf '%s' "${prompt}" | claude -p \
   --bare \
   --strict-mcp-config \
   --no-session-persistence \
-  --model haiku \
+  --model sonnet \
   --effort medium \
   --permission-mode acceptEdits \
   --allowed-tools "Read,Write,Edit,Glob,Grep" \

--- a/chezmoi/private_dot_agents/skills/okf/hooks/executable_okf-wiki-maintenance.sh
+++ b/chezmoi/private_dot_agents/skills/okf/hooks/executable_okf-wiki-maintenance.sh
@@ -5,11 +5,6 @@
 # data source only, no changes to memsearch itself.
 set -euo pipefail
 
-# Avoid recursing into our own hooks when the nested `claude -p` below exits.
-if [ "${MEMSEARCH_DISABLE:-}" = "1" ] || [ "${OKF_WIKI_DISABLE:-}" = "1" ]; then
-  exit 0
-fi
-
 MEMSEARCH_DIR="${MEMSEARCH_DIR:-${HOME}/.memsearch}"
 JOURNAL_DIR="${MEMSEARCH_DIR}/memory"
 WIKI_DIR="${OKF_WIKI_DIR:-${HOME}/wiki}"
@@ -37,19 +32,14 @@ if [ -f "${STATE_FILE}" ]; then
   fi
 fi
 
-# Memories since last run, or last 3 days on first run. Always include yesterday (-mtime -1 = <24h).
+# Memories since last run, or past day on first run.
 if [ -f "${STATE_FILE}" ]; then
   recent_memories="$(find "${JOURNAL_DIR}" -maxdepth 1 -name '*.md' \( -newer "${STATE_FILE}" -o -mtime -1 \) 2>/dev/null)"
 else
-  recent_memories="$(find "${JOURNAL_DIR}" -maxdepth 1 -name '*.md' -mtime -3 2>/dev/null)"
+  recent_memories="$(find "${JOURNAL_DIR}" -maxdepth 1 -name '*.md' -mtime -1 2>/dev/null)"
 fi
 
 [ -n "${recent_memories}" ] || exit 0
-
-export MEMSEARCH_DISABLE=1
-export MEMSEARCH_NO_WATCH=1
-export OKF_WIKI_DISABLE=1
-unset CLAUDECODE # clear CLAUDECODE so the child session doesn't inherit hook context
 
 # hook runs with async:true — Claude Code does not block on this script.
 # Run claude -p synchronously so mkdir lock holds for the full duration,
@@ -62,11 +52,14 @@ prompt="$(
   printf 'Recent memory:\n%s\n' "${recent_memories}"
 )"
 if printf '%s' "${prompt}" | claude -p \
-  --strict-mcp-config \
+  --bare \
   --no-session-persistence \
   --model haiku \
   --effort low \
+  --permission-mode acceptEdits \
   --allowed-tools "Read,Write,Edit,Glob,Grep" \
+  --plugin-dir "${HOME}/.claude/skills/okf" \
+  --exclude-dynamic-system-prompt-sections \
   --append-system-prompt-file "${PROMPT_FILE}" \
   --add-dir "${WIKI_DIR}" \
   --add-dir "${MEMSEARCH_DIR}" \

--- a/chezmoi/private_dot_agents/skills/okf/hooks/executable_okf-wiki-maintenance.sh
+++ b/chezmoi/private_dot_agents/skills/okf/hooks/executable_okf-wiki-maintenance.sh
@@ -5,15 +5,18 @@
 # data source only, no changes to memsearch itself.
 set -euo pipefail
 
+OKF_PLUGIN="${HOME}/.claude/skills/okf"
 MEMSEARCH_DIR="${MEMSEARCH_DIR:-${HOME}/.memsearch}"
 JOURNAL_DIR="${MEMSEARCH_DIR}/memory"
 WIKI_DIR="${OKF_WIKI_DIR:-${HOME}/wiki}"
 STATE_FILE="${WIKI_DIR}/.okf-wiki-last-run"
 LOCK_FILE="${WIKI_DIR}/.okf-wiki-maintenance.lock"
+LOG_FILE="${WIKI_DIR}/.okf-wiki-maintenance.log"
 PROMPT_FILE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/okf-wiki-review.txt"
 
 [ -d "${JOURNAL_DIR}" ] || exit 0
 [ -f "${PROMPT_FILE}" ] || exit 0
+[ -d "${OKF_PLUGIN}" ] || exit 0
 mkdir -p "${WIKI_DIR}"
 command -v claude &>/dev/null || exit 0
 
@@ -32,11 +35,11 @@ if [ -f "${STATE_FILE}" ]; then
   fi
 fi
 
-# Memories since last run, or past day on first run.
+# Memories since last run, or last 3 days on first run.
 if [ -f "${STATE_FILE}" ]; then
   recent_memories="$(find "${JOURNAL_DIR}" -maxdepth 1 -name '*.md' \( -newer "${STATE_FILE}" -o -mtime -1 \) 2>/dev/null)"
 else
-  recent_memories="$(find "${JOURNAL_DIR}" -maxdepth 1 -name '*.md' -mtime -1 2>/dev/null)"
+  recent_memories="$(find "${JOURNAL_DIR}" -maxdepth 1 -name '*.md' -mtime -3 2>/dev/null)"
 fi
 
 [ -n "${recent_memories}" ] || exit 0
@@ -53,18 +56,21 @@ prompt="$(
 )"
 if printf '%s' "${prompt}" | claude -p \
   --bare \
+  --strict-mcp-config \
   --no-session-persistence \
   --model haiku \
-  --effort low \
+  --effort medium \
   --permission-mode acceptEdits \
   --allowed-tools "Read,Write,Edit,Glob,Grep" \
-  --plugin-dir "${HOME}/.claude/skills/okf" \
+  --plugin-dir "${OKF_PLUGIN}" \
   --exclude-dynamic-system-prompt-sections \
   --append-system-prompt-file "${PROMPT_FILE}" \
   --add-dir "${WIKI_DIR}" \
   --add-dir "${MEMSEARCH_DIR}" \
-  >/dev/null 2>&1; then
+  >>"${LOG_FILE}" 2>&1; then
   date +%Y-%m-%d >"${STATE_FILE}"
+else
+  printf '%s okf-wiki-maintenance failed (exit %s)\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$?" >>"${LOG_FILE}"
 fi
 
 exit 0

--- a/chezmoi/private_dot_agents/skills/okf/hooks/executable_okf-wiki-maintenance.sh
+++ b/chezmoi/private_dot_agents/skills/okf/hooks/executable_okf-wiki-maintenance.sh
@@ -5,7 +5,7 @@
 # data source only, no changes to memsearch itself.
 set -euo pipefail
 
-OKF_PLUGIN="${HOME}/.claude/skills/okf"
+OKF_PLUGIN="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 MEMSEARCH_DIR="${MEMSEARCH_DIR:-${HOME}/.memsearch}"
 JOURNAL_DIR="${MEMSEARCH_DIR}/memory"
 WIKI_DIR="${OKF_WIKI_DIR:-${HOME}/wiki}"

--- a/chezmoi/private_dot_agents/skills/okf/hooks/okf-wiki-review.txt
+++ b/chezmoi/private_dot_agents/skills/okf/hooks/okf-wiki-review.txt
@@ -12,19 +12,19 @@ Step 2 — read `<wiki>/index.md` to understand the bundle's current structure.
 
 Step 3 — read the files listed under "Recent memory:" in the user message, plus any user profile and project review files listed.
 
-Step 4 — decide: is there anything worth adding or updating in the wiki?
-Lean toward capturing. Capture any of:
+Step 4 — extract every distinct topic worth capturing from the memory files. For each topic ask:
 - How something works — tools, systems, integrations, flags, invocation patterns
 - How something was set up or configured — steps, sequences, decisions made
 - Why something was done — rationale, tradeoffs, constraints
 - What was found — investigation results, things ruled out, gotchas
 - What worked or didn't — patterns, failure modes, workarounds
 
-Only skip if the knowledge is already fully covered by an existing concept, or if it is truly
-ephemeral (e.g. a one-line typo fix with no transferable lesson). When in doubt, add it.
+Only skip a topic if it is already fully covered by an existing concept, or if it is truly
+ephemeral (e.g. a one-line typo fix with no transferable lesson). When in doubt, include it.
 Prefer amending an existing concept over creating a new one for incremental additions.
 
-Step 5 — if there is durable knowledge, apply the skill's **maintain** mode.
+Step 5 — for each topic identified in Step 4, apply the skill's **maintain** mode. Work through
+all topics before finishing — do not stop after the first document. Process every topic.
 
 Constraints:
 - Do not touch memsearch-owned files (PROJECT.md, USER.md, memory .md files) — read-only to you.


### PR DESCRIPTION
## Summary

- Replace env-var recursion guards (`MEMSEARCH_DISABLE`, `OKF_WIKI_DISABLE`, `MEMSEARCH_NO_WATCH`) and `--strict-mcp-config` with `--bare`, which natively skips hooks, auto-memory, and CLAUDE.md discovery
- Load okf skill explicitly via `--plugin-dir` since `--bare` skips auto plugin loading
- Add `--permission-mode acceptEdits` for unattended file edits without prompts
- Add `--exclude-dynamic-system-prompt-sections` for better prompt cache reuse across daily runs
- Narrow first-run memory window from 3 days to 1 day

## Test plan

- [ ] Trigger SessionEnd and verify wiki maintenance runs without errors
- [ ] Verify state file written on success
- [ ] Verify no second run fires on same day (lock + state file guard)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Wiki maintenance now continues running even when either related disable setting is enabled.
  - Improved selection of recently updated memory entries, including safer handling when tracking information is unavailable.

- **Improvements**
  - Updated automated maintenance execution with clearer permission handling, non-persistent sessions, and more consistent tool and plugin configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->