### PR TITLE
fix(okf): switch to sonnet --effort low for wiki maintenance

### DIFF
--- a/chezmoi/.chezmoitemplates/memsearch_config.toml
+++ b/chezmoi/.chezmoitemplates/memsearch_config.toml
@@ -6,7 +6,6 @@ model = "Alibaba-NLP/gte-reranker-modernbert-base"
 
 [plugins.claude-code.project_review]
 enabled = true
-output_file = "~/.memsearch/PROJECT.md"
 
 [plugins.claude-code.user_profile]
 enabled = true
@@ -17,7 +16,6 @@ enabled = true
 
 [plugins.opencode.project_review]
 enabled = true
-output_file = "~/.memsearch/PROJECT.md"
 
 [plugins.opencode.user_profile]
 enabled = true

--- a/chezmoi/private_dot_agents/skills/okf/hooks/executable_okf-wiki-maintenance.sh
+++ b/chezmoi/private_dot_agents/skills/okf/hooks/executable_okf-wiki-maintenance.sh
@@ -59,7 +59,7 @@ if printf '%s' "${prompt}" | claude -p \
   --strict-mcp-config \
   --no-session-persistence \
   --model sonnet \
-  --effort medium \
+  --effort low \
   --permission-mode acceptEdits \
   --allowed-tools "Read,Write,Edit,Glob,Grep" \
   --plugin-dir "${OKF_PLUGIN}" \

--- a/chezmoi/private_dot_agents/skills/okf/hooks/okf-wiki-review.txt
+++ b/chezmoi/private_dot_agents/skills/okf/hooks/okf-wiki-review.txt
@@ -29,3 +29,5 @@ all topics before finishing — do not stop after the first document. Process ev
 Constraints:
 - Do not touch memsearch-owned files (PROJECT.md, USER.md, memory .md files) — read-only to you.
 - Do not ask questions. This runs unattended.
+- When updating log.md: check if today's date section already exists and append entries to it —
+  do not create a new section for the same date. One section per calendar date.


### PR DESCRIPTION
## Summary

- Switch model from `haiku` to `sonnet` for wiki maintenance hook
- Drop `--effort medium` to `--effort low` — wiki maintenance is structured extraction, not analytical reasoning; extended thinking budget is wasted

## Test plan

- [ ] Trigger SessionEnd and verify wiki maintenance runs, produces multiple concept file updates per run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted the wiki maintenance review process to use a lower effort setting.
  * All locking, state tracking, input handling, and logging behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->