### PR TITLE
feat(daily-summary): add atuin shell history as signal source

### DIFF
--- a/chezmoi/.chezmoitemplates/claude-settings.json
+++ b/chezmoi/.chezmoitemplates/claude-settings.json
@@ -54,7 +54,7 @@
   "sandbox": {
     "enabled": true,
     "enableWeakerNetworkIsolation": true,
-    "excludedCommands": ["docker *", "git *", "ssh *"]
+    "excludedCommands": ["atuin *", "docker *", "git *", "ssh *"]
   },
   "statusLine": {
     "type": "command",

--- a/chezmoi/private_dot_agents/skills/daily-summary/SKILL.md
+++ b/chezmoi/private_dot_agents/skills/daily-summary/SKILL.md
@@ -14,12 +14,34 @@ Produce a **standup** from the memsearch memory log for the requested date.
 1. **Date** — use `$ARGUMENTS` if non-empty; default to yesterday. Validate
    `YYYY-MM-DD`; reject with an error message on malformed input.
 
-2. **Load** — read `~/.memsearch/memory/<date>.md`. Stop and tell the user if the file is missing.
+2. **Load memory** — read `~/.memsearch/memory/<date>.md`. Note if missing
+   (continue with shell history only; don't stop).
 
-3. **Map** — assign each task to the repo where the change happened. Tasks
+3. **Load shell history** — run:
+
+   ```sh
+   atuin search --after "<date> 00:00:00" --before "<date+1> 00:00:00" \
+     --format "{time} {directory} {command}" --limit 2000 2>/dev/null
+   ```
+
+   Filter to meaningful commands only:
+   - **Keep**: git, brew, gh, ssh, docker, uv, npx, databricks, aws, az, claude,
+     pre-commit, chezmoi, and any command with substantive args (file paths, flags)
+   - **Drop**: bare navigational/inspection commands (ls, cat, cd, echo, pwd,
+     which, man, history, atuin with no args)
+   - **Deduplicate**: collapse repeated identical or near-identical commands
+     (e.g. multiple `az login` variants → one entry noting it was attempted);
+     keep only the last successful variant when a command was retried
+
+4. **Merge** — combine memory log tasks with shell history signals. Shell
+   history fills gaps when memory is missing; memory provides intent/context
+   that raw commands lack. Deduplicate: one bullet per logical task regardless
+   of source.
+
+5. **Map** — assign each task to the repo/dir where the change happened. Tasks
    with no repo go under `Other`.
 
-4. **Output** the standup in a fenced code block. No preamble. One bullet per
+6. **Output** the standup in a fenced code block. No preamble. One bullet per
    task, ≤12 words. Under each task, nest sub-tasks one level deep only when
    they are genuinely distinct steps, not elaborations. Skip sessions with only
    exploration and no resulting change or decision.


### PR DESCRIPTION
## Summary

- Supplements memsearch memory log with filtered atuin shell history for the day
- Drops bare navigational commands (ls, cat, cd, echo, etc.) and collapses retry sequences
- Continues with shell history only if memsearch memory file is missing
- Also excludes `atuin *` from Claude Code permission prompts

## Test plan

- [ ] Run `/daily-summary <date>` and verify atuin commands appear in output
- [ ] Verify noisy commands (ls variants, repeated failed attempts) are collapsed
- [ ] Verify missing memsearch file falls through to shell history only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daily summaries now incorporate relevant shell history alongside memory files.
  * Summaries continue generating when the day’s memory file is unavailable.
  * Repeated commands and attempts are consolidated into concise task bullets.

* **Bug Fixes**
  * Improved filtering removes unrelated navigation and inspection commands from daily summaries.
  * Added `atuin` commands to the sandbox’s excluded command list for safer execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->