### PR TITLE
fix(memsearch): disable project_review task and remove PROJECT.md references

### DIFF
--- a/chezmoi/.chezmoitemplates/memsearch_config.toml
+++ b/chezmoi/.chezmoitemplates/memsearch_config.toml
@@ -4,17 +4,11 @@ provider = "onnx"
 [reranker]
 model = "Alibaba-NLP/gte-reranker-modernbert-base"
 
-[plugins.claude-code.project_review]
-enabled = true
-
 [plugins.claude-code.user_profile]
 enabled = true
 output_file = "~/.memsearch/USER.md"
 
 [plugins.claude-code.memory_to_skill]
-enabled = true
-
-[plugins.opencode.project_review]
 enabled = true
 
 [plugins.opencode.user_profile]

--- a/chezmoi/private_dot_agents/skills/okf/hooks/executable_okf-wiki-maintenance.sh
+++ b/chezmoi/private_dot_agents/skills/okf/hooks/executable_okf-wiki-maintenance.sh
@@ -51,7 +51,6 @@ fi
 prompt="$(
   printf 'Wiki directory: %s\n' "${WIKI_DIR}"
   [ -f "${MEMSEARCH_DIR}/USER.md" ] && printf 'User profile: %s\n' "${MEMSEARCH_DIR}/USER.md"
-  [ -f "${MEMSEARCH_DIR}/PROJECT.md" ] && printf 'Project review: %s\n' "${MEMSEARCH_DIR}/PROJECT.md"
   printf 'Recent memory:\n%s\n' "${recent_memories}"
 )"
 if printf '%s' "${prompt}" | claude -p \

--- a/chezmoi/private_dot_agents/skills/okf/hooks/okf-wiki-review.txt
+++ b/chezmoi/private_dot_agents/skills/okf/hooks/okf-wiki-review.txt
@@ -1,9 +1,8 @@
 You are maintaining a personal OKF (Open Knowledge Format) wiki.
 
 You will receive recently-changed memsearch memory files (markdown logs of past coding sessions)
-and, when listed, memsearch-synthesized PROJECT.md (project review) and USER.md (user profile) as
-additional context. Treat synthesized summaries as primary; use raw memory files for detail not
-captured there.
+and, when listed, memsearch-synthesized USER.md (user profile) as additional context. Treat
+synthesized summaries as primary; use raw memory files for detail not captured there.
 
 Step 1 — invoke the `okf` skill. It defines the bundle layout, frontmatter rules, and the exact
 steps for adding, updating, and linking concepts. Follow it exactly for any edits you make.
@@ -27,7 +26,7 @@ Step 5 — for each topic identified in Step 4, apply the skill's **maintain** m
 all topics before finishing — do not stop after the first document. Process every topic.
 
 Constraints:
-- Do not touch memsearch-owned files (PROJECT.md, USER.md, memory .md files) — read-only to you.
+- Do not touch memsearch-owned files (USER.md, memory .md files) — read-only to you.
 - Do not ask questions. This runs unattended.
 - When updating log.md: check if today's date section already exists and append entries to it —
   do not create a new section for the same date. One section per calendar date.

--- a/chezmoi/private_dot_agents/skills/okf/hooks/okf-wiki-review.txt
+++ b/chezmoi/private_dot_agents/skills/okf/hooks/okf-wiki-review.txt
@@ -9,7 +9,7 @@ steps for adding, updating, and linking concepts. Follow it exactly for any edit
 
 Step 2 — read `<wiki>/index.md` to understand the bundle's current structure.
 
-Step 3 — read the files listed under "Recent memory:" in the user message, plus any user profile and project review files listed.
+Step 3 — read the files listed under "Recent memory:" in the user message, plus any user profile file listed.
 
 Step 4 — extract every distinct topic worth capturing from the memory files. For each topic ask:
 - How something works — tools, systems, integrations, flags, invocation patterns


### PR DESCRIPTION
## Summary

- Disable `project_review` maintenance task for `claude-code` and `opencode` plugins in memsearch config — not useful with `MEMSEARCH_DIR` global (single state key → only one project refreshes per digest cycle; journals are cross-project)
- Remove `PROJECT.md` from okf-wiki maintenance hook prompt construction
- Remove `PROJECT.md` references from okf-wiki prompt template

## Test plan

- [ ] Run `chezmoi apply` and verify `~/.memsearch/config.toml` has no `project_review` blocks
- [ ] Confirm okf-wiki maintenance hook no longer passes `Project review:` line in prompt
- [ ] Verify `~/.memsearch/USER.md` still updates normally via `user_profile` task

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed project review processing from automated memory and wiki workflows.
  * Continued support for user profile updates and memory-to-skill generation.
  * Wiki maintenance now uses the wiki content, user profile, and recent memory context.
  * Wiki review guidance now treats the user profile and memory files as protected inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->