### PR TITLE
feat: add acli skill for Jira and Confluence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 chezmoi/.chezmoidata.toml
 megalinter-reports
 settings.local.json
-chezmoi/private_dot_agents/skills/*-workspace/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 chezmoi/.chezmoidata.toml
 megalinter-reports
 settings.local.json
+chezmoi/private_dot_agents/skills/*-workspace/

--- a/chezmoi/private_dot_agents/skills/acli/SKILL.md
+++ b/chezmoi/private_dot_agents/skills/acli/SKILL.md
@@ -2,7 +2,7 @@
 name: acli
 description: >-
   Use when the user asks about Jira issues, JQL searches, sprints, boards,
-  or Confluence pages/spaces — or says "use acli" or "no MCP".
+  or Confluence pages/spaces, or says "use acli".
   Covers reading, creating, editing, transitioning, and commenting on Jira work
   items; listing sprints and boards; reading Confluence pages, spaces, and blogs.
 argument-hint: "[jira|confluence] <action> [args]"
@@ -52,7 +52,8 @@ acli jira workitem comment create --key "KEY-123" --body "Comment text"
 
 ```bash
 # Projects
-acli jira project list --json
+acli jira project list --limit 50 --json    # use --paginate for all pages
+acli jira project list --paginate --json
 acli jira project view --json   # prompts for project key
 
 # Boards

--- a/chezmoi/private_dot_agents/skills/acli/SKILL.md
+++ b/chezmoi/private_dot_agents/skills/acli/SKILL.md
@@ -1,19 +1,14 @@
 ---
 name: acli
-description: Interact with Jira and Confluence via the acli CLI. Use for reading/writing Jira issues, searching with JQL, managing sprints, and reading Confluence pages/spaces — without MCP.
+description: >-
+  Use when the user asks about Jira issues, JQL searches, sprints, boards,
+  or Confluence pages/spaces — or says "use acli" or "no MCP".
+  Covers reading, creating, editing, transitioning, and commenting on Jira work
+  items; listing sprints and boards; reading Confluence pages, spaces, and blogs.
 argument-hint: "[jira|confluence] <action> [args]"
 ---
 
 # acli — Atlassian CLI
-
-Interact with **Jira** and **Confluence** via the `acli` CLI. No MCP required.
-
-## When to use
-
-- Read or update Jira work items (view, search, create, edit, transition, comment)
-- Query sprints, boards, projects
-- Read Confluence pages, spaces, blog posts
-- User says "use acli", "no MCP", or references Jira/Confluence tasks
 
 ## Core commands
 
@@ -160,20 +155,20 @@ issueType = Epic
 issuetype in (Story, Task, Bug)
 ```
 
-## Output tips
+## Flags
 
-- Prefer `--json` for parsing; default output is human-readable tables
-- `--fields '*all'` returns every field; `--fields 'key,summary,status'` for minimal output
-- `--paginate` fetches all pages of results (search/list commands)
-- `--limit N` caps results
-- `--yes` / `-y` skips confirmation prompts on edit/transition/delete
+| Flag | Effect |
+| ---- | ------ |
+| `--json` | Machine-readable output (prefer for parsing) |
+| `--fields '*all'` | All fields; `--fields 'key,summary,status'` for minimal |
+| `--paginate` | Fetch all pages |
+| `--limit N` | Cap results |
+| `--yes` / `-y` | Skip confirmation on edit/transition/delete |
 
 ## Auth
 
 ```bash
-acli jira auth    # authenticate Jira (OAuth or API token)
-acli confluence auth    # authenticate Confluence
-acli auth    # top-level auth for all products
+acli jira auth        # Jira (OAuth or API token)
+acli confluence auth  # Confluence
+acli auth             # all products
 ```
-
-If commands fail with auth errors, run the appropriate `auth` command first.

--- a/chezmoi/private_dot_agents/skills/acli/SKILL.md
+++ b/chezmoi/private_dot_agents/skills/acli/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: acli
+description: Interact with Jira and Confluence via the acli CLI. Use for reading/writing Jira issues, searching with JQL, managing sprints, and reading Confluence pages/spaces — without MCP.
+argument-hint: "[jira|confluence] <action> [args]"
+---
+
+# acli — Atlassian CLI
+
+Interact with **Jira** and **Confluence** via the `acli` CLI. No MCP required.
+
+## When to use
+
+- Read or update Jira work items (view, search, create, edit, transition, comment)
+- Query sprints, boards, projects
+- Read Confluence pages, spaces, blog posts
+- User says "use acli", "no MCP", or references Jira/Confluence tasks
+
+## Core commands
+
+### Jira — work items
+
+```bash
+# View a work item (default fields: key, issuetype, summary, status, assignee, description)
+acli jira workitem view KEY-123
+acli jira workitem view KEY-123 --json
+acli jira workitem view KEY-123 --fields '*all'
+acli jira workitem view KEY-123 --fields 'summary,comment,status,assignee,priority,labels,description'
+
+# Search via JQL
+acli jira workitem search --jql "project = PROJ AND status = 'In Progress'" --json
+acli jira workitem search \
+  --jql "assignee = currentUser() AND sprint in openSprints()" \
+  --fields 'key,summary,status,priority' --json
+acli jira workitem search --jql "project = PROJ" --paginate --json   # all results
+
+# Create
+acli jira workitem create --summary "Title" --project "PROJ" --type "Task"
+acli jira workitem create \
+  --summary "Title" --project "PROJ" --type "Story" --assignee "@me" --description "Body"
+acli jira workitem create --summary "Title" --project "PROJ" --type "Bug" --parent "PROJ-10"
+
+# Edit
+acli jira workitem edit --key "KEY-123" --summary "New title"
+acli jira workitem edit --key "KEY-123" --description "Updated body" --yes
+acli jira workitem edit --key "KEY-123" --assignee "@me" --yes
+
+# Transition (change status)
+acli jira workitem transition --key "KEY-123" --status "In Progress" --yes
+acli jira workitem transition --key "KEY-123" --status "Done" --yes
+
+# Comments
+acli jira workitem comment list --key "KEY-123" --json
+acli jira workitem comment create --key "KEY-123" --body "Comment text"
+```
+
+### Jira — projects, boards, sprints
+
+```bash
+# Projects
+acli jira project list --json
+acli jira project view --json   # prompts for project key
+
+# Boards
+acli jira board search --json
+acli jira board search --project "PROJ" --json
+acli jira board search --name "My Board" --json
+
+# Sprints (requires board ID)
+acli jira board list-sprints --board <board-id> --json    # get sprint IDs
+acli jira sprint view --sprint <sprint-id> --json
+acli jira sprint list-workitems --sprint <sprint-id> --board <board-id> --json
+acli jira sprint list-workitems --sprint <sprint-id> --board <board-id> \
+  --fields 'key,summary,assignee,status,priority' --json
+```
+
+### Confluence — pages
+
+```bash
+# View page by ID
+acli confluence page view --id 123456789
+acli confluence page view --id 123456789 --json
+acli confluence page view --id 123456789 --body-format storage    # raw HTML/wiki
+acli confluence page view --id 123456789 --body-format view       # rendered
+acli confluence page view --id 123456789 --include-direct-children --include-labels --json
+```
+
+### Confluence — spaces
+
+```bash
+acli confluence space list --json
+acli confluence space list --type global --json
+acli confluence space view --json    # prompts for space key
+```
+
+### Confluence — blog posts
+
+```bash
+acli confluence blog list --space-id 12345 --json
+acli confluence blog list --space-id 12345 --title "Release Notes" --json
+acli confluence blog view --id 98765 --json
+acli confluence blog view --id 98765 --body-format storage
+```
+
+## Common patterns
+
+### Find and read a Jira issue
+
+```bash
+# 1. Search to find the key
+acli jira workitem search \
+  --jql "project = PROJ AND text ~ 'keyword'" --fields 'key,summary,status' --json
+
+# 2. Read full details
+acli jira workitem view KEY-123 --fields '*all' --json
+```
+
+### Current sprint work
+
+```bash
+# 1. Find board ID
+acli jira board search --project "PROJ" --json
+
+# 2. List sprints to get active sprint ID
+acli jira board list-sprints --board <board-id> --json
+
+# 3. List sprint items
+acli jira sprint list-workitems --sprint <sprint-id> --board <board-id> \
+  --fields 'key,summary,assignee,status,priority' --json
+```
+
+### Assign and transition
+
+```bash
+acli jira workitem edit --key "KEY-123" --assignee "@me" --yes
+acli jira workitem transition --key "KEY-123" --status "In Progress" --yes
+```
+
+### Add a comment
+
+```bash
+acli jira workitem comment create --key "KEY-123" --body "Investigated — root cause is X. Fix in KEY-124."
+```
+
+### JQL reference (common patterns)
+
+```text
+project = PROJ                              # by project
+assignee = currentUser()                    # my issues
+status = "In Progress"                      # by status
+status in ("To Do", "In Progress")          # multiple statuses
+sprint in openSprints()                     # active sprint
+sprint in openSprints() AND assignee = currentUser()
+priority = High
+text ~ "keyword"                            # full-text search
+labels = "my-label"
+created >= -7d                              # last 7 days
+updated >= "2026-07-01"
+parent = PROJ-10                            # subtasks of epic
+issueType = Epic
+issuetype in (Story, Task, Bug)
+```
+
+## Output tips
+
+- Prefer `--json` for parsing; default output is human-readable tables
+- `--fields '*all'` returns every field; `--fields 'key,summary,status'` for minimal output
+- `--paginate` fetches all pages of results (search/list commands)
+- `--limit N` caps results
+- `--yes` / `-y` skips confirmation prompts on edit/transition/delete
+
+## Auth
+
+```bash
+acli jira auth    # authenticate Jira (OAuth or API token)
+acli confluence auth    # authenticate Confluence
+acli auth    # top-level auth for all products
+```
+
+If commands fail with auth errors, run the appropriate `auth` command first.

--- a/chezmoi/private_dot_agents/skills/acli/evals/evals.json
+++ b/chezmoi/private_dot_agents/skills/acli/evals/evals.json
@@ -1,0 +1,39 @@
+{
+  "skill_name": "acli",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "List all my Jira projects that I have access to. Show the results as JSON.",
+      "expected_output": "Runs `acli jira project list --json` and outputs the project list",
+      "files": [],
+      "expectations": [
+        "Used `acli jira project list` command",
+        "Included `--json` flag or produced JSON-formatted output",
+        "Did not use curl or a REST API URL"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Search for any open Jira issues assigned to me that are currently in an active sprint. Show the key, summary, and status for each.",
+      "expected_output": "Runs `acli jira workitem search` with JQL using `assignee = currentUser() AND sprint in openSprints()` and appropriate fields",
+      "files": [],
+      "expectations": [
+        "Used `acli jira workitem search` command",
+        "JQL includes `sprint in openSprints()`",
+        "JQL includes `assignee = currentUser()`",
+        "Fields requested include key, summary, and status"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "List all Confluence spaces I have access to. Show results as JSON.",
+      "expected_output": "Runs `acli confluence space list --json` and outputs the space list",
+      "files": [],
+      "expectations": [
+        "Used `acli confluence space list` command",
+        "Included `--json` flag or produced JSON-formatted output",
+        "Did not use curl or a REST API URL"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `acli` skill for interacting with Jira and Confluence via the `acli` CLI
- Covers Jira work items (view, search, create, edit, transition, comment), projects, boards, sprints, and Confluence pages, spaces, and blogs
- Includes JQL reference cheat sheet and common workflow patterns
- Tightened per writing-great-skills guidelines (removed duplication, negation, no-ops)
- Fixed `acli jira project list` example to include `--paginate`/`--limit` (caught by eval run)
- Added `evals/evals.json` with 3 test cases

## Test plan

- [ ] `acli jira project list --limit 50 --json` works without error
- [ ] `acli jira workitem search --jql "assignee = currentUser() AND sprint in openSprints()" --fields key,summary,status --json` returns results
- [ ] `acli confluence space list --json` returns spaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide for using the Atlassian CLI skill across Jira and Confluence.
  * Documented common workflows, supported commands, JQL examples, authentication, and useful command options.

* **Tests**
  * Added evaluation scenarios covering Jira project and issue searches and Confluence space listings.
  * Added checks for expected command usage and structured output formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->