### PR TITLE
feat: add glab and databricks agent skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,19 @@ pre-commit install
 ./bin/cleanup-all.sh
 ```
 
-## Claude Code plugins
+## Agent skills
 
-Personal skills-directory plugin deployed by `chezmoi apply` to `~/.claude/skills/okf/`.
-Loaded automatically as `okf@skills-dir` on session start — no install step.
+Personal agent skills deployed by `chezmoi apply` to `~/.agents/skills/` and symlinked into `~/.claude/skills/`.
 
-Current plugins:
+Current skills:
 
+- `acli` — Jira issues, JQL searches, sprints, boards, and Confluence pages/spaces
+- `databricks` — Databricks jobs, clusters, pipelines, bundles, SQL warehouses, DBFS/volumes,
+  and workspace objects
+- `glab` — GitLab merge requests, issues, CI/CD pipelines, pipeline jobs, and repositories
 - `okf` — OKF skill + SessionEnd hook that distills memsearch journals into the `~/wiki` OKF bundle
-- `daily-summary` — standup digest skill that groups the day's memsearch activity log by repository
+- `update-summary` — standup digest from memsearch activity logs, grouped by repo;
+  supports date ranges and project filters
 
 ## License
 

--- a/bin/update-all.sh
+++ b/bin/update-all.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 if command -v gh >/dev/null; then
-  export GITHUB_TOKEN=$(gh auth token)
+  GITHUB_TOKEN=$(gh auth token)
+  export GITHUB_TOKEN
   trap 'unset GITHUB_TOKEN' EXIT
 fi
 

--- a/chezmoi/private_dot_agents/skills/acli/SKILL.md
+++ b/chezmoi/private_dot_agents/skills/acli/SKILL.md
@@ -156,13 +156,13 @@ issuetype in (Story, Task, Bug)
 
 ## Flags
 
-| Flag | Effect |
-| ---- | ------ |
-| `--json` | Machine-readable output (prefer for parsing) |
+| Flag              | Effect                                                  |
+|-------------------|---------------------------------------------------------|
+| `--json`          | Machine-readable output (prefer for parsing)            |
 | `--fields '*all'` | All fields; `--fields 'key,summary,status'` for minimal |
-| `--paginate` | Fetch all pages |
-| `--limit N` | Cap results |
-| `--yes` / `-y` | Skip confirmation on edit/transition/delete |
+| `--paginate`      | Fetch all pages                                         |
+| `--limit N`       | Cap results                                             |
+| `--yes` / `-y`    | Skip confirmation on edit/transition/delete             |
 
 ## Auth
 

--- a/chezmoi/private_dot_agents/skills/acli/SKILL.md
+++ b/chezmoi/private_dot_agents/skills/acli/SKILL.md
@@ -3,8 +3,6 @@ name: acli
 description: >-
   Use when the user asks about Jira issues, JQL searches, sprints, boards,
   or Confluence pages/spaces, or says "use acli".
-  Covers reading, creating, editing, transitioning, and commenting on Jira work
-  items; listing sprints and boards; reading Confluence pages, spaces, and blogs.
 argument-hint: "[jira|confluence] <action> [args]"
 ---
 

--- a/chezmoi/private_dot_agents/skills/databricks/SKILL.md
+++ b/chezmoi/private_dot_agents/skills/databricks/SKILL.md
@@ -166,13 +166,13 @@ databricks fs cp dbfs:/tmp/result.csv ./result.csv
 
 ## Flags
 
-| Flag | Effect |
-| ---- | ------ |
+| Flag            | Effect                                       |
+|-----------------|----------------------------------------------|
 | `--output json` | Machine-readable output (prefer for parsing) |
-| `-p <profile>` | Use named profile from `~/.databrickscfg` |
-| `-t <target>` | Bundle target (e.g. `dev`, `prod`) |
-| `--debug` | Verbose debug logging |
-| `--var "k=v"` | Override bundle variable |
+| `-p <profile>`  | Use named profile from `~/.databrickscfg`    |
+| `-t <target>`   | Bundle target (e.g. `dev`, `prod`)           |
+| `--debug`       | Verbose debug logging                        |
+| `--var "k=v"`   | Override bundle variable                     |
 
 ## Auth
 

--- a/chezmoi/private_dot_agents/skills/databricks/SKILL.md
+++ b/chezmoi/private_dot_agents/skills/databricks/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: databricks
+description: >-
+  Use when the user asks about Databricks jobs, clusters, pipelines, bundles,
+  SQL warehouses, DBFS/volumes, or workspace objects, or says "use databricks".
+argument-hint: "[jobs|clusters|bundle|fs|workspace|...] <action> [args]"
+---
+
+# databricks — Databricks CLI
+
+## Core commands
+
+### Jobs
+
+```bash
+# List
+databricks jobs list --output json
+databricks jobs list --output json | jq '.jobs[] | {id:.job_id, name:.settings.name}'
+
+# Get / run
+databricks jobs get --job-id 123 --output json
+databricks jobs run-now --job-id 123
+databricks jobs run-now --job-id 123 --job-parameters '{"key": "value"}'
+
+# Runs
+databricks jobs list-runs --job-id 123 --output json
+databricks jobs list-runs --active-only --output json
+databricks jobs get-run --run-id 456 --output json
+databricks jobs get-run-output --run-id 456 --output json
+databricks jobs cancel-run --run-id 456
+```
+
+### Clusters
+
+```bash
+# List / get
+databricks clusters list --output json
+databricks clusters get --cluster-id abc123 --output json
+
+# Lifecycle
+databricks clusters start --cluster-id abc123
+databricks clusters delete --cluster-id abc123   # terminate
+databricks clusters restart --cluster-id abc123
+
+# Spark versions / node types (for creating clusters)
+databricks clusters spark-versions --output json
+databricks clusters list-node-types --output json
+```
+
+### Bundles (DABs)
+
+```bash
+# Init and develop
+databricks bundle init default-python            # scaffold new project
+databricks bundle validate                       # check config
+databricks bundle plan --target dev
+
+# Deploy and run
+databricks bundle deploy --target dev
+databricks bundle deploy --target prod
+databricks bundle run my_job --target dev
+databricks bundle run my_pipeline --target dev
+
+# Inspect
+databricks bundle summary --target dev --output json
+
+# Import existing resources
+databricks bundle generate job --existing-job-id 123 --key my_job
+databricks bundle deployment bind my_job 123
+
+# Sync (file sync mode)
+databricks bundle sync --target dev
+```
+
+### Pipelines (Lakeflow / DLT)
+
+```bash
+databricks pipelines list --output json
+databricks pipelines get --pipeline-id abc123 --output json
+databricks pipelines start-update --pipeline-id abc123
+databricks pipelines history --pipeline-id abc123 --output json
+```
+
+### SQL warehouses
+
+```bash
+databricks warehouses list --output json
+databricks warehouses get --id abc123 --output json
+databricks warehouses start --id abc123
+databricks warehouses stop --id abc123
+```
+
+### Filesystem (DBFS / UC Volumes)
+
+```bash
+databricks fs ls dbfs:/path/
+databricks fs ls dbfs:/path/ --output json
+databricks fs cp local_file.csv dbfs:/path/file.csv
+databricks fs cp dbfs:/path/file.csv ./local/
+databricks fs cat dbfs:/path/file.txt
+databricks fs rm dbfs:/path/file.csv
+databricks fs mkdir dbfs:/path/dir/
+```
+
+### Workspace
+
+```bash
+# List / navigate
+databricks workspace list /Users/me@example.com --output json
+
+# Import / export
+databricks workspace export /path/notebook --output json > notebook.ipynb
+databricks workspace import ./notebook.py --path /path/notebook --language PYTHON
+databricks workspace export-dir /path/dir ./local-dir/
+databricks workspace import-dir ./local-dir/ /path/dir/
+```
+
+### Secrets
+
+```bash
+databricks secrets list-scopes --output json
+databricks secrets list --scope my-scope --output json
+databricks secrets put-secret --scope my-scope --key my-key --string-value "value"
+databricks secrets delete-secret --scope my-scope --key my-key
+```
+
+## Common patterns
+
+### Run a job and tail its output
+
+```bash
+# 1. Trigger
+RUN_ID=$(databricks jobs run-now --job-id 123 --output json | jq -r '.run_id')
+
+# 2. Poll until done
+databricks jobs get-run --run-id "$RUN_ID" --output json | jq '{state:.state.life_cycle_state, result:.state.result_state}'
+
+# 3. Get output
+databricks jobs get-run-output --run-id "$RUN_ID" --output json
+```
+
+### Deploy bundle and run
+
+```bash
+databricks bundle validate
+databricks bundle deploy --target dev
+databricks bundle run my_job --target dev
+```
+
+### Find a running cluster and check it
+
+```bash
+databricks clusters list --output json \
+  | jq '.clusters[] | select(.state == "RUNNING") | {id:.cluster_id, name:.cluster_name}'
+databricks clusters get --cluster-id <id> --output json \
+  | jq '{state:.state, spark:.spark_version, workers:.num_workers}'
+```
+
+### Copy local data to DBFS and back
+
+```bash
+databricks fs cp ./data.csv dbfs:/tmp/data.csv
+databricks fs ls dbfs:/tmp/ --output json
+databricks fs cp dbfs:/tmp/result.csv ./result.csv
+```
+
+## Flags
+
+| Flag | Effect |
+| ---- | ------ |
+| `--output json` | Machine-readable output (prefer for parsing) |
+| `-p <profile>` | Use named profile from `~/.databrickscfg` |
+| `-t <target>` | Bundle target (e.g. `dev`, `prod`) |
+| `--debug` | Verbose debug logging |
+| `--var "k=v"` | Override bundle variable |
+
+## Auth
+
+```bash
+databricks auth login --host https://<workspace>.azuredatabricks.net
+databricks auth profiles          # list configured profiles
+databricks auth describe          # show active credentials
+databricks configure              # interactive setup (~/.databrickscfg)
+```

--- a/chezmoi/private_dot_agents/skills/glab/SKILL.md
+++ b/chezmoi/private_dot_agents/skills/glab/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: glab
+description: >-
+  Use when the user asks about GitLab merge requests, issues, CI/CD pipelines,
+  pipeline jobs, or repositories, or says "use glab".
+argument-hint: "[mr|issue|ci] <action> [args]"
+---
+
+# glab — GitLab CLI
+
+## Core commands
+
+### Merge requests
+
+```bash
+# View
+glab mr view
+glab mr view 123
+glab mr view my-branch-name
+glab mr view 123 --comments
+
+# List
+glab mr list
+glab mr list --state all
+glab mr list --assignee @me
+glab mr list --label "bugfix" --output json
+glab mr list --search "keyword" --output json
+glab mr list --not-draft --output json
+
+# Create
+glab mr create --fill                                # title/desc from branch + commits
+glab mr create --title "Title" --description "Body"
+glab mr create --fill --draft
+glab mr create --fill --label "bugfix" --assignee @me
+glab mr create --fill --reviewer username --remove-source-branch
+glab mr create --fill --target-branch main
+
+# Update
+glab mr update 123 --title "New title"
+glab mr update 123 --description "Updated body"
+glab mr update 123 --assignee @me
+glab mr update 123 --label "ready" --unlabel "draft"
+glab mr update 123 --ready                           # unmark draft
+
+# Review / approval
+glab mr approve 123
+glab mr revoke 123
+glab mr diff 123
+glab mr diff 123 --output json
+
+# Merge
+glab mr merge 123
+glab mr merge 123 --squash
+glab mr merge 123 --remove-source-branch
+glab mr merge 123 --auto-merge                       # merge when CI passes
+
+# Comments / discussions
+glab mr note 123 --message "Comment text"
+
+# Other lifecycle
+glab mr close 123
+glab mr reopen 123
+glab mr rebase 123
+glab mr checkout 123
+```
+
+### Issues
+
+```bash
+# View
+glab issue view 456
+glab issue view 456 --comments
+
+# List
+glab issue list
+glab issue list --state all --output json
+glab issue list --assignee @me --output json
+glab issue list --label "bug" --output json
+glab issue list --search "keyword" --output json
+glab issue list --milestone "v2.0" --output json
+
+# Create
+glab issue create --title "Bug: X breaks Y"
+glab issue create --title "Title" --description "Body" --label "bug" --assignee @me
+
+# Update
+glab issue update 456 --title "New title"
+glab issue update 456 --label "confirmed" --assignee @me
+
+# Lifecycle
+glab issue close 456
+glab issue reopen 456
+
+# Comments
+glab issue note 456 --message "Comment text"
+```
+
+### CI/CD pipelines
+
+```bash
+# defaults to current branch
+glab ci status
+glab ci status --branch main
+
+glab ci list
+glab ci list --status running --output json
+glab ci list --branch main --output json
+
+# TUI job picker
+glab ci view
+glab ci view --branch main
+
+glab ci get --pipeline-id 789 --output json
+glab ci run
+glab ci run --branch main
+glab ci cancel --pipeline-id 789
+glab ci retry --pipeline-id 789
+
+# interactive picker when no arg
+glab ci trace
+glab ci trace 1234
+glab ci trace job-name
+
+glab ci trigger job-name
+glab ci artifact HEAD job-name --path ./artifacts
+```
+
+### Repository / project
+
+```bash
+glab repo clone owner/project
+glab repo clone owner/group/project
+glab repo view --web
+glab repo fork owner/project
+```
+
+## Common patterns
+
+### Review an open MR
+
+```bash
+# 1. View summary
+glab mr view 123
+
+# 2. See the diff
+glab mr diff 123
+
+# 3. Check CI status
+glab ci status --branch <mr-branch>
+
+# 4. Approve and merge
+glab mr approve 123
+glab mr merge 123 --squash --remove-source-branch
+```
+
+### Find and fix a failing pipeline
+
+```bash
+# 1. Check status
+glab ci status
+
+# 2. View jobs (pick the failing one)
+glab ci view
+
+# 3. Stream its log
+glab ci trace <job-name>
+
+# 4. Retry after fixing
+glab ci retry <job-id>
+```
+
+### Create an MR from current branch
+
+```bash
+glab mr create --fill --draft --remove-source-branch
+# review, then mark ready:
+glab mr update --ready
+```
+
+### Searching across a group
+
+```bash
+glab issue list -g my-group --search "login" --output json
+glab mr list -g my-group --state all --assignee @me --output json
+```
+
+## Flags
+
+| Flag | Effect |
+| ---- | ------ |
+| `--output json` | Machine-readable output (prefer for parsing) |
+| `--assignee @me` | Filter to current authenticated user |
+| `--state all\|opened\|closed\|merged` | Filter by state |
+| `--label <name>` | Filter by label (repeatable) |
+| `--milestone <name>` | Filter by milestone |
+| `--search <str>` | Full-text search in title/description |
+| `--jq <expr>` | Apply jq filter to JSON output |
+| `--paginate` | Fetch all pages |
+| `-R <owner/repo>` | Target a different project |
+| `-g <group>` | Target a group instead of a project |
+| `--web` | Open result in browser |
+| `-y / --yes` | Skip confirmation prompts |
+
+## Auth
+
+```bash
+glab auth login
+glab auth status
+```

--- a/chezmoi/private_dot_agents/skills/glab/SKILL.md
+++ b/chezmoi/private_dot_agents/skills/glab/SKILL.md
@@ -186,20 +186,20 @@ glab mr list -g my-group --state all --assignee @me --output json
 
 ## Flags
 
-| Flag | Effect |
-| ---- | ------ |
-| `--output json` | Machine-readable output (prefer for parsing) |
-| `--assignee @me` | Filter to current authenticated user |
-| `--state all\|opened\|closed\|merged` | Filter by state |
-| `--label <name>` | Filter by label (repeatable) |
-| `--milestone <name>` | Filter by milestone |
-| `--search <str>` | Full-text search in title/description |
-| `--jq <expr>` | Apply jq filter to JSON output |
-| `--paginate` | Fetch all pages |
-| `-R <owner/repo>` | Target a different project |
-| `-g <group>` | Target a group instead of a project |
-| `--web` | Open result in browser |
-| `-y / --yes` | Skip confirmation prompts |
+| Flag                                  | Effect                                       |
+|---------------------------------------|----------------------------------------------|
+| `--output json`                       | Machine-readable output (prefer for parsing) |
+| `--assignee @me`                      | Filter to current authenticated user         |
+| `--state all\|opened\|closed\|merged` | Filter by state                              |
+| `--label <name>`                      | Filter by label (repeatable)                 |
+| `--milestone <name>`                  | Filter by milestone                          |
+| `--search <str>`                      | Full-text search in title/description        |
+| `--jq <expr>`                         | Apply jq filter to JSON output               |
+| `--paginate`                          | Fetch all pages                              |
+| `-R <owner/repo>`                     | Target a different project                   |
+| `-g <group>`                          | Target a group instead of a project          |
+| `--web`                               | Open result in browser                       |
+| `-y / --yes`                          | Skip confirmation prompts                    |
 
 ## Auth
 

--- a/chezmoi/private_dot_claude/skills/symlink_acli
+++ b/chezmoi/private_dot_claude/skills/symlink_acli
@@ -1,0 +1,1 @@
+../../.agents/skills/acli

--- a/chezmoi/private_dot_claude/skills/symlink_databricks
+++ b/chezmoi/private_dot_claude/skills/symlink_databricks
@@ -1,0 +1,1 @@
+../../.agents/skills/databricks

--- a/chezmoi/private_dot_claude/skills/symlink_glab
+++ b/chezmoi/private_dot_claude/skills/symlink_glab
@@ -1,0 +1,1 @@
+../../.agents/skills/glab


### PR DESCRIPTION
## Summary

- Add `glab` skill covering merge requests, issues, CI/CD pipelines, and repositories
- Add `databricks` skill covering jobs, clusters, bundles, pipelines, warehouses, DBFS, workspace, secrets
- Add chezmoi symlinks wiring `acli`, `glab`, and `databricks` into `~/.claude/skills/`
- Trim identity sentences from `acli` and `glab` descriptions (body already covers scope; description is for triggering only)
- Update README: consolidate agent skills into a single section, rename `daily-summary` → `update-summary`

## Test plan

- [ ] `chezmoi apply` creates `~/.claude/skills/{acli,glab,databricks}` symlinks
- [ ] All three skills appear in Claude Code's available skills list
- [ ] Skills trigger on relevant questions (GitLab MR/issue/CI, Databricks jobs/clusters/bundles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)