### PR TITLE
feat(git): add https support and glab credential helper for sgts

### DIFF
--- a/chezmoi/.chezmoitemplates/claude-settings.json
+++ b/chezmoi/.chezmoitemplates/claude-settings.json
@@ -54,7 +54,7 @@
   "sandbox": {
     "enabled": true,
     "enableWeakerNetworkIsolation": true,
-    "excludedCommands": ["atuin *", "docker *", "git *", "ssh *"]
+    "excludedCommands": ["atuin *", "docker *", "ssh *"]
   },
   "statusLine": {
     "type": "command",

--- a/chezmoi/private_dot_config/git/config.tmpl
+++ b/chezmoi/private_dot_config/git/config.tmpl
@@ -92,6 +92,9 @@
 [includeIf "gitdir:~/work/"]
   path = "~/.config/git/work_config"
 
+[includeIf "hasconfig:remote.*.url:https://sgts.gitlab-dedicated.com/**"]
+  path = "~/.config/git/work_config"
+
 [includeIf "hasconfig:remote.*.url:git@sgts.gitlab-dedicated.com:**"]
   path = "~/.config/git/work_config"
 {{- end }}

--- a/chezmoi/private_dot_config/git/config.tmpl
+++ b/chezmoi/private_dot_config/git/config.tmpl
@@ -8,10 +8,10 @@
 
 {{- if lookPath "gh" }}
 [credential "https://gist.github.com"]
-  helper = "gh auth git-credential"
+  helper = "!gh auth git-credential"
 
 [credential "https://github.com"]
-  helper = "gh auth git-credential"
+  helper = "!gh auth git-credential"
 {{- end }}
 
 [delta]

--- a/chezmoi/private_dot_config/git/ignore.tmpl
+++ b/chezmoi/private_dot_config/git/ignore.tmpl
@@ -1,4 +1,4 @@
-{{- template "gitignore" . }}
+{{- template "gitignore" . -}}
 
 .env
 .env.*

--- a/chezmoi/private_dot_config/git/ignore.tmpl
+++ b/chezmoi/private_dot_config/git/ignore.tmpl
@@ -7,6 +7,8 @@
 
 *.bak
 .cache
+*-cache
+*_cache
 *.lock
 .tmp
 

--- a/chezmoi/private_dot_config/git/work_config.tmpl
+++ b/chezmoi/private_dot_config/git/work_config.tmpl
@@ -11,6 +11,6 @@
 
 {{- if lookPath "glab" }}
 [credential "https://sgts.gitlab-dedicated.com"]
-  helper = "glab auth git-credential"
+  helper = "!glab auth git-credential"
 {{- end }}
 {{- end }}

--- a/chezmoi/private_dot_config/git/work_config.tmpl
+++ b/chezmoi/private_dot_config/git/work_config.tmpl
@@ -1,4 +1,4 @@
-{{- if not .is_ephemeral }}
+{{- if not .is_ephemeral -}}
 [user]
   email = "{{ .git_email_work }}"
   signingkey = ~/.ssh/id_ed25519.pub

--- a/chezmoi/private_dot_config/git/work_config.tmpl
+++ b/chezmoi/private_dot_config/git/work_config.tmpl
@@ -8,4 +8,9 @@
 
 [commit]
   gpgsign = true
+
+{{- if lookPath "glab" }}
+[credential "https://sgts.gitlab-dedicated.com"]
+  helper = "glab auth git-credential"
+{{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary

- Add `hasconfig` `includeIf` for `https://sgts.gitlab-dedicated.com/**` URLs so work config is applied for HTTPS remotes
- Add `glab auth git-credential` helper for `https://sgts.gitlab-dedicated.com` in work_config
- Remove duplicate SSH `hasconfig` entry

## Test plan

- [ ] Clone/fetch a repo via `https://sgts.gitlab-dedicated.com/...` and verify glab credential is used
- [ ] Verify work user config still applies for SSH remotes (`git@sgts.gitlab-dedicated.com`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Git automatically applies work-specific settings for both SSH and HTTPS GitLab repositories.
  * Added GitLab credential management through the GitLab CLI when available.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->