### PR TITLE
fix: revert-git-exclude-commands

### DIFF
--- a/chezmoi/.chezmoitemplates/claude-settings.json
+++ b/chezmoi/.chezmoitemplates/claude-settings.json
@@ -54,7 +54,7 @@
   "sandbox": {
     "enabled": true,
     "enableWeakerNetworkIsolation": true,
-    "excludedCommands": ["atuin *", "docker *", "ssh *"]
+    "excludedCommands": ["atuin *", "docker *", "git *", "ssh *"]
   },
   "statusLine": {
     "type": "command",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated sandbox settings to block Git commands, providing an additional safeguard during automated operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->