### PR TITLE
chore(deps): ignore java patch updates in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,11 @@
       "groupName": "python",
       "matchPackageNames": ["python"],
       "matchUpdateTypes": ["major", "minor"]
+    },
+    {
+      "matchPackageNames": ["java"],
+      "matchUpdateTypes": ["patch"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Disable Renovate patch updates for `java` to avoid noisy PRs like #936
- Major and minor updates still tracked

## Test plan
- [ ] Verify Renovate no longer opens PRs for java patch versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)