### PR TITLE
fix: caveman

### DIFF
--- a/chezmoi/.chezmoiscripts/run_onchange_after_agent_plugins.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_after_agent_plugins.sh.tmpl
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+npm install -g @caveman-ai/cli
+caveman setup --install
+
 if command -v codebase-memory-mcp >/dev/null; then
   codebase-memory-mcp install --yes
   codebase-memory-mcp config set auto_index true

--- a/chezmoi/.chezmoiscripts/run_onchange_after_setup_opencode.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_after_setup_opencode.sh.tmpl
@@ -8,5 +8,3 @@ fi
 if ! command -v opencode >/dev/null; then
   npm install --global opencode-ai
 fi
-
-npx --yes --allow-git=all -- github:JuliusBrussee/caveman -- --only opencode


### PR DESCRIPTION
# Notes

Update caveman install commands — old `npx github:JuliusBrussee/caveman -- --only opencode` broken on npm 12 (EALLOWGIT) and requires local clone. Replace with current install path.

# Jira ticket

N/A

# Changes

- Remove stale `npx --yes --allow-git=all -- github:JuliusBrussee/caveman -- --only opencode` from opencode setup script
- Add `npm install -g @caveman-ai/cli && caveman setup --install` to agent plugins script

# Tests

No tests — chezmoi install script change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Changelog

Changelog: fixed