### PR TITLE
feat: add lean-ctx and codebase-memory CLI skills

### DIFF
--- a/chezmoi/.chezmoiscripts/run_onchange_after_agent_plugins.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_after_agent_plugins.sh.tmpl
@@ -17,9 +17,6 @@ fi
 {{- end }}
 
 if command -v lean-ctx >/dev/null; then
-  if command -v claude >/dev/null; then
-    lean-ctx wrap claude
-  fi
   if command -v opencode >/dev/null; then
     lean-ctx wrap opencode
   fi

--- a/chezmoi/private_dot_agents/skills/codebase-memory/SKILL.md
+++ b/chezmoi/private_dot_agents/skills/codebase-memory/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: codebase-memory
+description: >-
+  Use the codebase knowledge graph for structural code queries. Triggers on:
+  explore the codebase, understand the architecture, what functions exist,
+  show me the structure, who calls this function, what does X call,
+  trace the call chain, find callers of, show dependencies, impact analysis,
+  dead code, unused functions, high fan-out, refactor candidates,
+  code quality audit, graph query syntax, Cypher examples, edge types.
+---
+
+# Codebase Memory — Knowledge Graph Tools
+
+Graph tools return precise structural results in ~500 tokens vs ~80K for grep.
+
+**All tools run via CLI** (no MCP server required):
+
+```bash
+codebase-memory-mcp cli <tool> '<json-args>'
+# or pipe JSON:
+echo '<json>' | codebase-memory-mcp cli <tool>
+```
+
+## Quick Decision Matrix
+
+| Question | Tool call |
+| ---------- | ---------- |
+| Who calls X? | `trace_path` with `"direction":"inbound"` |
+| What does X call? | `trace_path` with `"direction":"outbound"` |
+| Full call context | `trace_path` with `"direction":"both"` |
+| Find by name pattern | `search_graph` with `"name_pattern":"..."` |
+| Dead code | `search_graph` with `"max_degree":0,"exclude_entry_points":true` |
+| Cross-service edges | `query_graph` with Cypher |
+| Impact of local changes | `detect_changes` |
+| Risk-classified trace | `trace_path` with `"risk_labels":true` |
+| Text search | `search_code` or Grep |
+
+## Exploration Workflow
+
+1. `codebase-memory-mcp cli list_projects '{}'` — check if project is indexed
+2. `codebase-memory-mcp cli get_graph_schema '{"project":"<id>"}'` — understand node/edge types
+3. `codebase-memory-mcp cli search_graph '{"project":"<id>","label":"Function","name_pattern":".*"}'`
+4. `codebase-memory-mcp cli get_code_snippet '{"project":"<id>","qualified_name":"path.FuncName"}'`
+
+## Tracing Workflow
+
+1. `codebase-memory-mcp cli search_graph '{"project":"<id>","name_pattern":".*FuncName.*"}'`
+2. `codebase-memory-mcp cli trace_path '{"project":"<id>","function_name":"FuncName","direction":"both"}'`
+3. `codebase-memory-mcp cli detect_changes '{"project":"<id>"}'` — map git diff to symbols
+
+## Quality Analysis
+
+- Dead code: `search_graph` with `"max_degree":0,"exclude_entry_points":true`
+- High fan-out: `search_graph` with `"min_degree":10,"relationship":"CALLS","direction":"outbound"`
+- High fan-in: `search_graph` with `"min_degree":10,"relationship":"CALLS","direction":"inbound"`
+
+## 15 CLI Tools
+
+`index_repository`, `index_status`, `list_projects`, `delete_project`,
+`search_graph`, `search_code`, `trace_path`, `detect_changes`,
+`query_graph`, `get_graph_schema`, `get_code_snippet`, `get_architecture`,
+`manage_adr`, `ingest_traces`, `check_index_coverage`
+
+## Edge Types
+
+CALLS, HTTP_CALLS, ASYNC_CALLS, IMPORTS, DEFINES, DEFINES_METHOD,
+HANDLES, IMPLEMENTS, OVERRIDE, USAGE, FILE_CHANGES_WITH,
+CONTAINS_FILE, CONTAINS_FOLDER, CONTAINS_PACKAGE
+
+## Cypher Examples
+
+```bash
+codebase-memory-mcp cli query_graph \
+  '{"project":"<id>","query":"MATCH (a)-[r:HTTP_CALLS]->(b) RETURN a.name, b.name LIMIT 20"}'
+codebase-memory-mcp cli query_graph \
+  '{"project":"<id>","query":"MATCH (f:Function) WHERE f.name =~ \".*Handler.*\" RETURN f.name"}'
+```
+
+## Gotchas
+
+1. `"relationship":"HTTP_CALLS"` in `search_graph` filters by degree — use `query_graph` for edges.
+2. `query_graph` has a 200-row cap — use `search_graph` with degree filters for counting.
+3. `trace_path` needs exact names — use `search_graph` with `name_pattern` first.
+4. `"direction":"outbound"` misses cross-service callers — use `"direction":"both"`.
+5. Results default to 10 per page — check `has_more` and use `offset`.

--- a/chezmoi/private_dot_agents/skills/codebase-memory/SKILL.md
+++ b/chezmoi/private_dot_agents/skills/codebase-memory/SKILL.md
@@ -23,17 +23,17 @@ echo '<json>' | codebase-memory-mcp cli <tool>
 
 ## Quick Decision Matrix
 
-| Question | Tool call |
-| ---------- | ---------- |
-| Who calls X? | `trace_path` with `"direction":"inbound"` |
-| What does X call? | `trace_path` with `"direction":"outbound"` |
-| Full call context | `trace_path` with `"direction":"both"` |
-| Find by name pattern | `search_graph` with `"name_pattern":"..."` |
-| Dead code | `search_graph` with `"max_degree":0,"exclude_entry_points":true` |
-| Cross-service edges | `query_graph` with Cypher |
-| Impact of local changes | `detect_changes` |
-| Risk-classified trace | `trace_path` with `"risk_labels":true` |
-| Text search | `search_code` or Grep |
+| Question                | Tool call                                                        |
+|-------------------------|------------------------------------------------------------------|
+| Who calls X?            | `trace_path` with `"direction":"inbound"`                        |
+| What does X call?       | `trace_path` with `"direction":"outbound"`                       |
+| Full call context       | `trace_path` with `"direction":"both"`                           |
+| Find by name pattern    | `search_graph` with `"name_pattern":"..."`                       |
+| Dead code               | `search_graph` with `"max_degree":0,"exclude_entry_points":true` |
+| Cross-service edges     | `query_graph` with Cypher                                        |
+| Impact of local changes | `detect_changes`                                                 |
+| Risk-classified trace   | `trace_path` with `"risk_labels":true`                           |
+| Text search             | `search_code` or Grep                                            |
 
 ## Exploration Workflow
 

--- a/chezmoi/private_dot_agents/skills/lean-ctx/SKILL.md
+++ b/chezmoi/private_dot_agents/skills/lean-ctx/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: lean-ctx
+description: Compress large Bash/file/grep output before it enters context. Use when command output > ~500 lines, file reads > ~200 lines, grep spanning many files, or user says "use lean-ctx".
+---
+
+# lean-ctx
+
+```bash
+lean-ctx -c "<command>"        # shell command, compressed
+lean-ctx read <file>            # file, compressed
+lean-ctx grep <pattern> [path]  # search, compressed
+lean-ctx raw "<command>"        # uncompressed escape hatch
+```
+
+Route through lean-ctx when output is large. Use Read/Bash/Grep directly when output is
+small or needed verbatim (diffs, exact error strings, structured data to parse).

--- a/chezmoi/private_dot_claude/skills/symlink_codebase-memory
+++ b/chezmoi/private_dot_claude/skills/symlink_codebase-memory
@@ -1,0 +1,1 @@
+../../.agents/skills/codebase-memory

--- a/chezmoi/private_dot_claude/skills/symlink_lean-ctx
+++ b/chezmoi/private_dot_claude/skills/symlink_lean-ctx
@@ -1,0 +1,1 @@
+../../.agents/skills/lean-ctx


### PR DESCRIPTION
## Summary

- Add `lean-ctx` skill: CLI output compression via `lean-ctx -c/read/grep`, no MCP required
- Add `codebase-memory` skill: graph queries via `codebase-memory-mcp cli <tool>`, no MCP required
- Remove `lean-ctx wrap claude` from agent plugins script (MCP disallowed by company policy)

Both skills follow the existing pattern: source in `private_dot_agents/skills/`, symlinked from `private_dot_claude/skills/`.

## Test plan

- [ ] `chezmoi apply` installs skills to `~/.agents/skills/` and symlinks to `~/.claude/skills/`
- [ ] `lean-ctx -c "echo hello"` returns compressed output
- [ ] `codebase-memory-mcp cli list_projects '{}'` returns indexed projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)