### PR TITLE
refactor: cleanup-opencode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,6 +68,7 @@ repos:
     rev: v0.21.0
     hooks:
       - id: yamlfmt
+        exclude: /modify_.*\.ya?ml$
 
 ci:
   autoupdate_commit_msg: "ci: pre-commit autoupdate"

--- a/chezmoi/.chezmoitemplates/omp-config.yml
+++ b/chezmoi/.chezmoitemplates/omp-config.yml
@@ -1,0 +1,11 @@
+modelRoles:
+  default: opencode-go/deepseek-v4-flash
+  vision: opencode-go/mimo-v2.5
+symbolPreset: unicode
+theme:
+  dark: titanium
+  light: light
+setupVersion: 2
+defaultThinkingLevel: auto
+composer:
+  shape: box

--- a/chezmoi/.chezmoitemplates/omp-config.yml
+++ b/chezmoi/.chezmoitemplates/omp-config.yml
@@ -1,6 +1,3 @@
-modelRoles:
-  default: opencode-go/deepseek-v4-flash
-  vision: opencode-go/mimo-v2.5
 symbolPreset: unicode
 theme:
   dark: titanium

--- a/chezmoi/.chezmoitemplates/opencode.json
+++ b/chezmoi/.chezmoitemplates/opencode.json
@@ -2,8 +2,6 @@
   "$schema": "https://opencode.ai/config.json",
   "formatter": true,
   "lsp": true,
-  "model": "opencode/deepseek-v4-flash-free",
-  "small_model": "opencode/deepseek-v4-flash-free",
   "compaction": {
     "prune": true
   },
@@ -15,19 +13,10 @@
       "~/wiki/**": "allow"
     }
   },
-  "plugin": [
-    "openslimedit",
-    "@dietrichgebert/ponytail",
-    "@zilliz/memsearch-opencode"
-  ],
+  "plugin": ["@dietrichgebert/ponytail", "@zilliz/memsearch-opencode"],
   "mcp": {
     "codebase-memory-mcp": {
       "command": ["codebase-memory-mcp"],
-      "enabled": true,
-      "type": "local"
-    },
-    "playwright": {
-      "command": ["npx", "--yes", "@playwright/mcp"],
       "enabled": true,
       "type": "local"
     }

--- a/chezmoi/private_dot_omp/agent/modify_config.yml
+++ b/chezmoi/private_dot_omp/agent/modify_config.yml
@@ -1,7 +1,7 @@
 {{- /* chezmoi:modify-template */ -}}
 {{- $current := dict -}}
 {{- if .chezmoi.stdin | trim -}}
-{{-   $current = fromJson .chezmoi.stdin -}}
+{{-   $current = fromYaml .chezmoi.stdin -}}
 {{- end -}}
-{{- $template := includeTemplate "omp-config.yml" . | fromJson -}}
+{{- $template := includeTemplate "omp-config.yml" . | fromYaml -}}
 {{ mergeOverwrite $current $template | toYaml }}

--- a/chezmoi/private_dot_omp/agent/modify_config.yml
+++ b/chezmoi/private_dot_omp/agent/modify_config.yml
@@ -1,0 +1,7 @@
+{{- /* chezmoi:modify-template */ -}}
+{{- $current := dict -}}
+{{- if .chezmoi.stdin | trim -}}
+{{-   $current = fromJson .chezmoi.stdin -}}
+{{- end -}}
+{{- $template := includeTemplate "omp-config.yml" . | fromJson -}}
+{{ mergeOverwrite $current $template | toYaml }}


### PR DESCRIPTION
## Changes

- Remove hardcoded `model` and `small_model` from opencode config template
- Remove `openslimedit` plugin
- Remove `playwright` MCP server
- Manage `~/.omp/agent/config.yml` via chezmoi modify template (merges template over existing config)
- Add yamlfmt exclude for `modify_*.yml` files (consistent with taplo/markdownlint excludes)